### PR TITLE
fix: use parent session key for subagent completion announce delivery

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -345,6 +345,78 @@ describe("resolveSubagentCompletionOrigin", () => {
       to: "channel:parent-main",
     });
   });
+
+  it("never uses child agent accountId for cross-app Feishu delivery (issue #106)", async () => {
+    // Simulate the Feishu cross-app scenario: parent uses "default" app,
+    // child agent uses "QMT-assistant" app. The child binding shares the same
+    // conversationId as the requester, which would cause a requester-match
+    // if childSessionKey were used for resolution.
+    registerSessionBindingAdapter({
+      channel: "feishu",
+      accountId: "QMT-assistant",
+      listBySession: (targetSessionKey: string) => {
+        if (targetSessionKey === "agent:qmt-assistant:subagent:task1") {
+          return [
+            {
+              bindingId: "feishu:QMT-assistant:oc_parent_chat",
+              targetSessionKey,
+              targetKind: "subagent",
+              conversation: {
+                channel: "feishu",
+                accountId: "QMT-assistant",
+                conversationId: "oc_parent_chat",
+              },
+              status: "active",
+              boundAt: 1,
+            },
+          ];
+        }
+        return [];
+      },
+      resolveByConversation: () => null,
+    });
+    registerSessionBindingAdapter({
+      channel: "feishu",
+      accountId: "default",
+      listBySession: (targetSessionKey: string) => {
+        if (targetSessionKey === "agent:main:main") {
+          return [
+            {
+              bindingId: "feishu:default:oc_parent_chat",
+              targetSessionKey,
+              targetKind: "session",
+              conversation: {
+                channel: "feishu",
+                accountId: "default",
+                conversationId: "oc_parent_chat",
+              },
+              status: "active",
+              boundAt: 1,
+            },
+          ];
+        }
+        return [];
+      },
+      resolveByConversation: () => null,
+    });
+
+    const origin = await resolveSubagentCompletionOrigin({
+      childSessionKey: "agent:qmt-assistant:subagent:task1",
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: {
+        channel: "feishu",
+        accountId: "default",
+        to: "oc_parent_chat",
+      },
+      spawnMode: "session",
+      expectsCompletionMessage: true,
+    });
+
+    // Must use the parent's "default" accountId, NOT the child's "QMT-assistant"
+    expect(origin).toBeDefined();
+    expect(origin!.accountId).toBe("default");
+    expect(origin!.channel).toBe("feishu");
+  });
 });
 
 describe("deliverSubagentAnnouncement queued delivery", () => {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -308,23 +308,6 @@ export async function resolveSubagentCompletionOrigin(params: {
     channel && conversationId ? { channel, accountId, conversationId } : undefined;
 
   const router = createBoundDeliveryRouter();
-  const childRoute = router.resolveDestination({
-    eventKind: "task_completion",
-    targetSessionKey: params.childSessionKey,
-    requester: requesterConversation,
-    failClosed: true,
-  });
-  if (childRoute.mode === "bound" && childRoute.binding) {
-    return mergeDeliveryContext(
-      resolveBoundConversationOrigin({
-        bindingConversation: childRoute.binding.conversation,
-        requesterConversation,
-        requesterOrigin,
-      }),
-      requesterOrigin,
-    );
-  }
-
   const route = router.resolveDestination({
     eventKind: "task_completion",
     targetSessionKey: params.requesterSessionKey,


### PR DESCRIPTION
## Bug

- **Symptom**: Subagent completion announce delivery fails with Feishu API 400 error `code 99992361: open_id cross app` when parent and child agents use different Feishu app accounts.
- **Root cause**: `resolveSubagentCompletionOrigin()` in `subagent-announce-delivery.ts` called `resolveDestination()` with `targetSessionKey: params.childSessionKey` first, which resolved to the child agent's Feishu app binding (`accountId: "QMT-assistant"`). This accountId was then used to send the reply back to the parent session's user, whose `open_id` belongs to a different Feishu app (`accountId: "default"`).
- **Impact**: 17+ failed deliveries; all subagent completion announcements silently fail when agents use different Feishu apps.

## Fix

Removed the child session key resolution path from `resolveSubagentCompletionOrigin()`. The announce delivery back to the parent user now always resolves using `params.requesterSessionKey` (the parent session), ensuring the correct Feishu app accountId is used.

### Changed files
- `src/agents/subagent-announce-delivery.ts` — removed the `childSessionKey` resolution block (lines 311-326), keeping only the `requesterSessionKey` resolution
- `src/agents/subagent-announce-delivery.test.ts` — added Feishu cross-app regression test

## Verification

- All 53 tests pass across `subagent-announce-delivery.test.ts` and `bound-delivery-router.test.ts`
- New regression test validates that Feishu cross-app scenario uses parent's accountId

Closes #106