### PR TITLE
fix: prevent heartbeat model from leaking into user session status

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1123,6 +1123,10 @@ async function agentCommandInternal(
     // Update token+model fields in the session store.
     if (sessionStore && sessionKey) {
       const { updateSessionStoreAfterAgentRun } = await loadSessionStoreRuntime();
+      const isBackgroundRun =
+        opts.bootstrapContextRunKind === "cron" ||
+        opts.bootstrapContextRunKind === "heartbeat" ||
+        !!opts.internalEvents?.length;
       await updateSessionStoreAfterAgentRun({
         cfg,
         contextTokensOverride: agentCfg?.contextTokens,
@@ -1135,10 +1139,8 @@ async function agentCommandInternal(
         fallbackProvider,
         fallbackModel,
         result,
-        touchInteraction:
-          opts.bootstrapContextRunKind !== "cron" &&
-          opts.bootstrapContextRunKind !== "heartbeat" &&
-          !opts.internalEvents?.length,
+        touchInteraction: !isBackgroundRun,
+        skipRuntimeModelPersist: isBackgroundRun,
       });
       sessionEntry = sessionStore[sessionKey] ?? sessionEntry;
     }

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -877,6 +877,123 @@ describe("updateSessionStoreAfterAgentRun", () => {
       expect(sessionStore[sessionKey]?.lastInteractionAt).toBeGreaterThan(lastInteractionAt);
     });
   });
+
+  it("does not overwrite session model when skipRuntimeModelPersist is true (fixes #45)", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-heartbeat-model-leak";
+      const sessionId = "test-heartbeat-model-leak-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: Date.now() - 10_000,
+          modelProvider: "openai-codex",
+          model: "gpt-5.5",
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      // Simulate a heartbeat run that uses a different model
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "xai",
+        defaultModel: "grok-4-1-fast",
+        result: {
+          meta: {
+            durationMs: 1,
+            agentMeta: {
+              sessionId,
+              provider: "xai",
+              model: "grok-4-1-fast",
+            },
+          },
+        },
+        touchInteraction: false,
+        skipRuntimeModelPersist: true,
+      });
+
+      // AC-1: model/modelProvider must remain unchanged
+      expect(sessionStore[sessionKey]?.model).toBe("gpt-5.5");
+      expect(sessionStore[sessionKey]?.modelProvider).toBe("openai-codex");
+
+      // AC-4: on-disk persistence also reflects the unchanged model
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.model).toBe("gpt-5.5");
+      expect(persisted[sessionKey]?.modelProvider).toBe("openai-codex");
+    });
+  });
+
+  it("still updates token fields when skipRuntimeModelPersist is true (fixes #45)", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        models: {
+          providers: {
+            xai: {
+              models: [
+                {
+                  id: "grok-4-1-fast",
+                  cost: {
+                    input: 5,
+                    output: 15,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-heartbeat-tokens";
+      const sessionId = "test-heartbeat-tokens-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: Date.now() - 10_000,
+          modelProvider: "openai-codex",
+          model: "gpt-5.5",
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      // Simulate heartbeat run with usage data
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "xai",
+        defaultModel: "grok-4-1-fast",
+        result: {
+          meta: {
+            durationMs: 1,
+            agentMeta: {
+              sessionId,
+              provider: "xai",
+              model: "grok-4-1-fast",
+              usage: {
+                input: 5000,
+                output: 1000,
+              },
+            },
+          },
+        },
+        touchInteraction: false,
+        skipRuntimeModelPersist: true,
+      });
+
+      // AC-3: token/cost fields ARE updated even with skipRuntimeModelPersist
+      expect(sessionStore[sessionKey]?.inputTokens).toBe(5000);
+      expect(sessionStore[sessionKey]?.outputTokens).toBe(1000);
+
+      // But model fields remain unchanged
+      expect(sessionStore[sessionKey]?.model).toBe("gpt-5.5");
+      expect(sessionStore[sessionKey]?.modelProvider).toBe("openai-codex");
+    });
+  });
 });
 
 describe("clearCliSessionInStore", () => {

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -50,6 +50,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   fallbackModel?: string;
   result: RunResult;
   touchInteraction?: boolean;
+  skipRuntimeModelPersist?: boolean;
 }) {
   const {
     cfg,
@@ -105,10 +106,14 @@ export async function updateSessionStoreAfterAgentRun(params: {
     lastInteractionAt: touchInteraction ? now : entry.lastInteractionAt,
     contextTokens,
   };
-  setSessionRuntimeModel(next, {
-    provider: providerUsed,
-    model: modelUsed,
-  });
+  // Skip runtime model persistence for heartbeat/cron runs so that background
+  // models do not leak into the user-facing session status. (Fixes #45.)
+  if (!params.skipRuntimeModelPersist) {
+    setSessionRuntimeModel(next, {
+      provider: providerUsed,
+      model: modelUsed,
+    });
+  }
   if (agentHarnessId) {
     next.agentHarnessId = agentHarnessId;
   } else if (result.meta.executionTrace?.runner === "cli") {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -363,7 +363,11 @@ export async function getReplyFromConfig(
       sessionCtx.ParentSessionKey,
     defaultProvider,
   });
-  if (storedModelOverride?.model && !hasResolvedHeartbeatModelOverride) {
+  // For heartbeat runs, always use fresh config defaults (either explicit heartbeat.model
+  // or agents.defaults.model.primary). Never inherit the stale stored session model override
+  // from sessions.json, which was pinned at session creation time and does not reflect
+  // openclaw.json edits across restarts. (Fixes #45, follow-up to #51677.)
+  if (storedModelOverride?.model && !hasResolvedHeartbeatModelOverride && !opts?.isHeartbeat) {
     provider = storedModelOverride.provider ?? defaultProvider;
     model = storedModelOverride.model;
   }


### PR DESCRIPTION
## Bug
- **Symptom**: `/status` reports the heartbeat model (e.g. `xai/grok-4-1-fast`) as the user's active model after a heartbeat run, even though normal turns use the configured default (`openai-codex/gpt-5.5`)
- **Root cause**: `updateSessionStoreAfterAgentRun()` unconditionally calls `setSessionRuntimeModel()` for all runs including heartbeat/cron, persisting the background model into `sessions.json`

## Fix
- Add `skipRuntimeModelPersist` option to `updateSessionStoreAfterAgentRun()` that skips `setSessionRuntimeModel()` when `true`
- Pass `skipRuntimeModelPersist: true` for heartbeat/cron/internalEvents runs (refactored `isBackgroundRun` variable in `agent-command.ts`)
- Skip stored model override inheritance for heartbeat runs in `get-reply.ts`

## Verification
- Regression tests: 2 new tests added, 36/36 pass in `session-store.test.ts`
- Model switch tests: 24/24 pass in `agent-command.live-model-switch.test.ts`
- Validation ladder: unit tests → integration-level tests, all pass
- Residual risk: `get-reply.ts` heartbeat model override change not directly unit-tested (existing test structure), but primary persistence fix is fully covered

Closes #45