### PR TITLE
fix: skip preflight compaction for /new and /reset commands

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -605,4 +605,47 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.bootstrapPromptWarningSignaturesSeen).toEqual(["sig-a", "sig-b"]);
     expect(flushCall.bootstrapPromptWarningSignature).toBe("sig-b");
   });
+
+  it.each(["/new", "/reset", "/new some-agent", "/reset extra args"])(
+    "skips preflight compaction for reset command: %s",
+    async (prompt) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+        "utf8",
+      );
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        sessionFile,
+        updatedAt: Date.now(),
+        totalTokens: 120_000,
+        compactionCount: 0,
+      };
+
+      const followupRun = createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+        provider: "discord",
+      });
+      (followupRun as unknown as { prompt: string }).prompt = prompt;
+
+      const entry = await runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: {} } } },
+        followupRun,
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100_000,
+        sessionEntry,
+        sessionStore: { main: sessionEntry },
+        sessionKey: "main",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+      });
+
+      expect(entry).toBe(sessionEntry);
+      expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -415,6 +415,15 @@ export async function runPreflightCompactionIfNeeded(params: {
     return entry ?? params.sessionEntry;
   }
 
+  // Reset commands (/new, /reset) clear the session entirely — compaction is
+  // unnecessary and would hold a WRITE lock long enough to trip Discord's
+  // InteractionEventListener 30 s deadline.  Bypass using the same pattern
+  // already established in commands-reset.ts.
+  const isResetCommand = /^\/(new|reset)(?:\s|$)/.test(params.followupRun.prompt ?? "");
+  if (isResetCommand) {
+    return entry ?? params.sessionEntry;
+  }
+
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     cfg: params.cfg,
     provider: params.followupRun.run.provider,


### PR DESCRIPTION
## Bug

- **Symptom**: Discord `/new` and `/reset` slash commands time out with "The application did not respond" when the session exceeds ~104K tokens
- **Root cause**: `runPreflightCompactionIfNeeded` holds a WRITE lock for 60-360s during preflight compaction, exceeding Discord's `InteractionEventListener` 30s deadline. Reset commands were not bypassed like `isHeartbeat` and `isCli` already are, even though they clear the session entirely and don't need compaction.

## Fix

Added an early return in `runPreflightCompactionIfNeeded` (`agent-runner-memory.ts`) for prompts matching `/^\/(new|reset)(?:\s|$)/` — the same pattern already established in `commands-reset.ts`. This bypasses unnecessary compaction work and lets reset commands proceed immediately within Discord's timeout window.

## Verification

- 4 new regression tests covering `/new`, `/reset`, `/new <args>`, `/reset <args>` — all confirm compaction is skipped
- All 13 existing tests pass — non-reset commands continue to trigger compaction normally
- Test command: `npx vitest run src/auto-reply/reply/agent-runner-memory.test.ts`

Closes #41