### PR TITLE
fix: skip unsupported ACP config keys instead of throwing

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -601,10 +601,10 @@ export class AcpSessionManager {
           .filter(Boolean) as string[],
       );
       if (advertisedKeys.size > 0 && !advertisedKeys.has(key)) {
-        throw new AcpRuntimeError(
-          "ACP_BACKEND_UNSUPPORTED_CONTROL",
-          `ACP backend "${handle.backend || meta.backend}" does not accept config key "${key}".`,
+        logVerbose(
+          `acp-manager: skipping unsupported config key "${key}" for ACP backend "${handle.backend || meta.backend}". Advertised keys: ${[...advertisedKeys].join(", ")}.`,
         );
+        return resolveRuntimeOptionsFromMeta(meta);
       }
 
       await withAcpRuntimeErrorBoundary({

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -1,3 +1,4 @@
+import { logVerbose } from "../../globals.js";
 import { AcpRuntimeError, withAcpRuntimeErrorBoundary } from "../runtime/errors.js";
 import type { AcpRuntime, AcpRuntimeCapabilities, AcpRuntimeHandle } from "../runtime/types.js";
 import type { SessionAcpMeta } from "./manager.types.js";
@@ -95,10 +96,10 @@ export async function applyManagerRuntimeControls(params: {
         }
         for (const [key, value] of configOptions) {
           if (advertisedKeys.size > 0 && !advertisedKeys.has(key)) {
-            throw new AcpRuntimeError(
-              "ACP_BACKEND_UNSUPPORTED_CONTROL",
-              `ACP backend "${backend}" does not accept config key "${key}".`,
+            logVerbose(
+              `acp-manager: skipping unsupported config key "${key}" for ACP backend "${backend}". Advertised keys: ${[...advertisedKeys].join(", ")}.`,
             );
+            continue;
           }
           await params.runtime.setConfigOption({
             handle: params.handle,

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -3113,4 +3113,172 @@ describe("AcpSessionManager", () => {
       }),
     ).rejects.toThrow("disk locked");
   });
+
+  it("skips unsupported config keys during runTurn when backend advertises narrow configOptionKeys", async () => {
+    const runtimeState = createRuntime();
+    // Override getCapabilities to advertise only "model" and "effort"
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+      configOptionKeys: ["model", "effort"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: {
+        ...readySessionMeta(),
+        runtimeOptions: {
+          model: "claude-sonnet-4-20250514",
+          thinking: "high",
+          permissionProfile: "strict",
+          timeoutSeconds: 120,
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-1",
+    });
+
+    // "model" is advertised → should be sent
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "model", value: "claude-sonnet-4-20250514" }),
+    );
+    // "thinking", "approval_policy", "timeout" are NOT advertised → should be skipped
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalledWith(
+      expect.objectContaining({ key: "thinking" }),
+    );
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalledWith(
+      expect.objectContaining({ key: "approval_policy" }),
+    );
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalledWith(
+      expect.objectContaining({ key: "timeout" }),
+    );
+    // Should have been called exactly once (for "model")
+    expect(runtimeState.setConfigOption).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips unsupported key in setSessionConfigOption and returns current options", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+      configOptionKeys: ["model", "effort"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+
+    const manager = new AcpSessionManager();
+    // "thinking" is not in configOptionKeys → should skip gracefully and return options
+    const result = await manager.setSessionConfigOption({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      key: "thinking",
+      value: "high",
+    });
+
+    expect(result).toBeDefined();
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalled();
+  });
+
+  it("passes through all config keys when configOptionKeys is not advertised", async () => {
+    const runtimeState = createRuntime();
+    // No configOptionKeys → all keys should pass through
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: {
+        ...readySessionMeta(),
+        runtimeOptions: {
+          model: "claude-sonnet-4-20250514",
+          thinking: "high",
+          permissionProfile: "strict",
+          timeoutSeconds: 120,
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-1",
+    });
+
+    // All four config options should be sent
+    expect(runtimeState.setConfigOption).toHaveBeenCalledTimes(4);
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "model" }),
+    );
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "thinking" }),
+    );
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "approval_policy" }),
+    );
+    expect(runtimeState.setConfigOption).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "timeout" }),
+    );
+  });
+
+  it("skips all config keys when none match advertised configOptionKeys", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+      configOptionKeys: ["effort", "max_tokens"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: {
+        ...readySessionMeta(),
+        runtimeOptions: {
+          model: "claude-sonnet-4-20250514",
+          thinking: "high",
+          permissionProfile: "strict",
+          timeoutSeconds: 120,
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-1",
+    });
+
+    // None of the runtime option keys (model, thinking, approval_policy, timeout) match
+    // the advertised keys (effort, max_tokens) → setConfigOption should never be called
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- **Root cause**: `applyManagerRuntimeControls()` and `setSessionConfigOption()` threw `AcpRuntimeError("ACP_BACKEND_UNSUPPORTED_CONTROL")` when encountering config keys not in the adapter's advertised `configOptionKeys`. The Claude ACP adapter only advertises `["mode", "model", "effort"]`, but OpenClaw sends `thinking`, `approval_policy`, and `timeout`.
- **Fix**: Changed both throw sites to log a verbose warning and skip/continue instead of crashing. Unsupported keys are gracefully ignored while supported keys are still sent.
- **Tests**: Added 4 regression tests covering narrow `configOptionKeys`, explicit `setSessionConfigOption` skip, passthrough when no keys advertised, and all-keys-unsupported edge case. All 59 tests pass (55 existing + 4 new).

Fixes #42

## Changes

| File | Change |
|------|--------|
| `src/acp/control-plane/manager.runtime-controls.ts` | Replace throw with `logVerbose` + `continue` for unsupported keys during `runTurn` |
| `src/acp/control-plane/manager.core.ts` | Replace throw with `logVerbose` + early return for unsupported keys in `setSessionConfigOption` |
| `src/acp/control-plane/manager.test.ts` | Add 4 regression tests for fail-soft config key handling |

## Test plan

- [x] All 55 existing tests pass (no regressions)
- [x] New test: skip unsupported keys during runTurn with narrow configOptionKeys
- [x] New test: skip unsupported key in setSessionConfigOption
- [x] New test: passthrough all keys when configOptionKeys not advertised
- [x] New test: skip all keys when none match advertised configOptionKeys