### PR TITLE
fix: drop orphan tool calls after LCM compaction instead of inserting synthetic errors

### DIFF
--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -544,7 +544,11 @@ export function pruneHistoryForContextShare(params: {
     // orphaned tool_results (whose tool_use was in the dropped chunk).
     // repairToolUseResultPairing drops orphaned tool_results, preventing
     // "unexpected tool_use_id" errors from Anthropic's API.
-    const repairReport = repairToolUseResultPairing(flatRest);
+    // Use "drop-tool-call" policy so orphan tool calls (whose results were in the
+    // dropped chunk) are stripped instead of getting synthetic error results.
+    const repairReport = repairToolUseResultPairing(flatRest, {
+      missingToolResultPolicy: "drop-tool-call",
+    });
     const repairedKept = repairReport.messages;
 
     // Track orphaned tool_results as dropped (they were in kept but their tool_use was dropped)

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -644,7 +644,11 @@ function splitPreservedRecentTurns(params: {
   const summarizableMessages = params.messages.filter((_, idx) => !preservedIndexSet.has(idx));
   // Preserving recent assistant turns can orphan downstream toolResult messages.
   // Repair pairings here so compaction summarization doesn't trip strict providers.
-  const repairedSummarizableMessages = repairToolUseResultPairing(summarizableMessages).messages;
+  // Use "drop-tool-call" policy so orphan tool calls (whose results moved to the
+  // preserved portion) are stripped instead of getting synthetic error results.
+  const repairedSummarizableMessages = repairToolUseResultPairing(summarizableMessages, {
+    missingToolResultPolicy: "drop-tool-call",
+  }).messages;
   const preservedMessages = params.messages
     .filter((_, idx) => preservedIndexSet.has(idx))
     .filter((msg) => {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -770,3 +770,166 @@ describe("stripToolResultDetails", () => {
     expect(out).toBe(input);
   });
 });
+
+describe("repairToolUseResultPairing with missingToolResultPolicy: drop-tool-call", () => {
+  it("drops orphan tool call blocks from assistant content instead of synthesizing errors", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check that." },
+          { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+        ],
+      },
+      { role: "user", content: "thanks" },
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      missingToolResultPolicy: "drop-tool-call",
+    });
+
+    // No synthetic error results should be added
+    expect(result.added).toHaveLength(0);
+    // Assistant message should still exist but without the orphan tool call
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]?.role).toBe("assistant");
+    expect(result.messages[1]?.role).toBe("user");
+    // The assistant content should only have the text block, not the tool call
+    const assistantContent = (result.messages[0] as { content: unknown[] }).content;
+    expect(assistantContent).toHaveLength(1);
+    expect((assistantContent[0] as { type: string }).type).toBe("text");
+  });
+
+  it("drops entire assistant message when all tool calls are orphaned", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+          { type: "toolCall", id: "call_2", name: "exec", arguments: {} },
+        ],
+      },
+      { role: "user", content: "next" },
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      missingToolResultPolicy: "drop-tool-call",
+    });
+
+    expect(result.added).toHaveLength(0);
+    // Assistant message should be dropped entirely since all tool calls are orphaned
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
+  });
+
+  it("preserves surviving tool calls and strips only orphaned ones in mixed turns", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+          { type: "toolCall", id: "call_2", name: "exec", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_2",
+        toolName: "exec",
+        content: [{ type: "text", text: "done" }],
+        isError: false,
+      },
+      { role: "user", content: "next" },
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      missingToolResultPolicy: "drop-tool-call",
+    });
+
+    expect(result.added).toHaveLength(0);
+    // Should have: assistant (with only call_2), toolResult for call_2, user
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[0]?.role).toBe("assistant");
+    expect(result.messages[1]?.role).toBe("toolResult");
+    expect((result.messages[1] as { toolCallId?: string }).toolCallId).toBe("call_2");
+    expect(result.messages[2]?.role).toBe("user");
+    // Assistant content should only have call_2
+    const assistantContent = (result.messages[0] as { content: unknown[] }).content;
+    const toolCallBlocks = assistantContent.filter(
+      (b) => (b as { type?: string }).type === "toolCall",
+    );
+    expect(toolCallBlocks).toHaveLength(1);
+    expect((toolCallBlocks[0] as { id?: string }).id).toBe("call_2");
+  });
+
+  it("preserves non-tool-call content blocks when stripping orphan tool calls", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I will read and execute." },
+          { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+          { type: "toolCall", id: "call_2", name: "exec", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "file contents" }],
+        isError: false,
+      },
+      { role: "user", content: "next" },
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      missingToolResultPolicy: "drop-tool-call",
+    });
+
+    expect(result.added).toHaveLength(0);
+    expect(result.messages).toHaveLength(3);
+    // Assistant content should have text block + call_1 (surviving), but not call_2 (orphaned)
+    const assistantContent = (result.messages[0] as { content: unknown[] }).content;
+    expect(assistantContent).toHaveLength(2);
+    expect((assistantContent[0] as { type: string }).type).toBe("text");
+    expect((assistantContent[1] as { type: string; id: string }).id).toBe("call_1");
+  });
+
+  it("still synthesizes error results when default policy is used (no option)", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+      { role: "user", content: "next" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    // Default behavior: synthetic error result should be inserted
+    expect(result.added).toHaveLength(1);
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[0]?.role).toBe("assistant");
+    expect(result.messages[1]?.role).toBe("toolResult");
+    expect((result.messages[1] as { isError?: boolean }).isError).toBe(true);
+    expect(result.messages[2]?.role).toBe("user");
+  });
+
+  it("still synthesizes error results when policy is explicitly synthesize-error", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+      { role: "user", content: "next" },
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      missingToolResultPolicy: "synthesize-error",
+    });
+
+    expect(result.added).toHaveLength(1);
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[1]?.role).toBe("toolResult");
+    expect((result.messages[1] as { isError?: boolean }).isError).toBe(true);
+  });
+});

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -260,9 +260,12 @@ export type ToolCallInputRepairOptions = {
 
 export type ErroredAssistantResultPolicy = "preserve" | "drop";
 
+export type MissingToolResultPolicy = "synthesize-error" | "drop-tool-call";
+
 export type ToolUseResultPairingOptions = {
   erroredAssistantResultPolicy?: ErroredAssistantResultPolicy;
   missingToolResultText?: string;
+  missingToolResultPolicy?: MissingToolResultPolicy;
 };
 
 export function stripToolResultDetails(messages: AgentMessage[]): AgentMessage[] {
@@ -444,6 +447,10 @@ function shouldDropErroredAssistantResults(options?: ToolUseResultPairingOptions
   return options?.erroredAssistantResultPolicy === "drop";
 }
 
+function shouldDropOrphanToolCalls(options?: ToolUseResultPairingOptions): boolean {
+  return options?.missingToolResultPolicy === "drop-tool-call";
+}
+
 export function repairToolUseResultPairing(
   messages: AgentMessage[],
   options?: ToolUseResultPairingOptions,
@@ -581,28 +588,99 @@ export function repairToolUseResultPairing(
       continue;
     }
 
-    out.push(msg);
+    if (shouldDropOrphanToolCalls(options)) {
+      // "drop-tool-call" policy: strip orphan tool call blocks from assistant
+      // content instead of inserting synthetic error results. This is used by
+      // compaction callers where missing results are expected (compacted away)
+      // rather than indicative of transcript corruption.
+      const orphanCallIds = new Set<string>();
+      const survivingCallIds = new Set<string>();
+      for (const call of toolCalls) {
+        if (spanResultsById.has(call.id)) {
+          survivingCallIds.add(call.id);
+        } else {
+          orphanCallIds.add(call.id);
+        }
+      }
 
-    if (spanResultsById.size > 0 && remainder.length > 0) {
-      // Preserve real late-arriving results before synthesizing missing siblings;
-      // otherwise parallel tool replay can replace useful output with repair noise.
-      moved = true;
-      changed = true;
-    }
-
-    for (const call of toolCalls) {
-      const existing = spanResultsById.get(call.id);
-      if (existing) {
-        pushToolResult(existing);
-      } else {
-        const missing = makeMissingToolResult({
-          toolCallId: call.id,
-          toolName: call.name,
-          text: options?.missingToolResultText,
-        });
-        added.push(missing);
+      if (orphanCallIds.size > 0) {
         changed = true;
-        pushToolResult(missing);
+      }
+
+      if (survivingCallIds.size === 0) {
+        // All tool calls are orphaned. Check if there is non-tool-call content
+        // (text blocks, thinking blocks, etc.) worth preserving.
+        if (Array.isArray(assistant.content)) {
+          const rawContent = assistant.content as unknown[];
+          const nonToolCallContent = rawContent.filter((block) => !isRawToolCallBlock(block));
+          if (nonToolCallContent.length > 0) {
+            // Preserve the assistant message with only the non-tool-call content.
+            out.push({ ...msg, content: nonToolCallContent } as AgentMessage);
+          }
+          // else: no remaining content — drop the entire assistant message.
+        }
+        // If content is not an array, drop the message (malformed).
+      } else {
+        // Some tool calls survive — strip only the orphaned tool call blocks
+        // from the assistant content.
+        if (orphanCallIds.size > 0 && Array.isArray(assistant.content)) {
+          const rawContent = assistant.content as unknown[];
+          const filteredContent = rawContent.filter((block) => {
+            if (!isRawToolCallBlock(block)) {
+              return true;
+            }
+            const blockId =
+              typeof (block as RawToolCallBlock).id === "string"
+                ? ((block as RawToolCallBlock).id as string).trim()
+                : "";
+            return !orphanCallIds.has(blockId);
+          });
+          out.push({ ...msg, content: filteredContent } as AgentMessage);
+        } else {
+          out.push(msg);
+        }
+        // Emit results for surviving tool calls only.
+        for (const call of toolCalls) {
+          if (!survivingCallIds.has(call.id)) {
+            continue;
+          }
+          const existing = spanResultsById.get(call.id);
+          if (existing) {
+            pushToolResult(existing);
+          }
+        }
+      }
+
+      if (spanResultsById.size > 0 && remainder.length > 0) {
+        moved = true;
+        changed = true;
+      }
+    } else {
+      // Default "synthesize-error" policy: insert synthetic error results for
+      // any tool call without a matching result.
+      out.push(msg);
+
+      if (spanResultsById.size > 0 && remainder.length > 0) {
+        // Preserve real late-arriving results before synthesizing missing siblings;
+        // otherwise parallel tool replay can replace useful output with repair noise.
+        moved = true;
+        changed = true;
+      }
+
+      for (const call of toolCalls) {
+        const existing = spanResultsById.get(call.id);
+        if (existing) {
+          pushToolResult(existing);
+        } else {
+          const missing = makeMissingToolResult({
+            toolCallId: call.id,
+            toolName: call.name,
+            text: options?.missingToolResultText,
+          });
+          added.push(missing);
+          changed = true;
+          pushToolResult(missing);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Adds `missingToolResultPolicy` option (`"synthesize-error" | "drop-tool-call"`) to `repairToolUseResultPairing` in `session-transcript-repair.ts`
- When policy is `"drop-tool-call"`, orphan tool call blocks are stripped from assistant messages instead of getting synthetic error results injected
- Both compaction callers (`compaction.ts` chunk drop and `compaction-safeguard.ts` preserved turns split) now use `"drop-tool-call"` policy
- Default behavior unchanged — callers without the option still get synthetic error results for backward compatibility

## Root Cause
After LCM compaction removes older messages, `repairToolUseResultPairing` unconditionally inserted synthetic error messages (`[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.`) for tool calls whose results were intentionally compacted away. This polluted the transcript and confused model reasoning.

## Changes
| File | Change |
|------|--------|
| `src/agents/session-transcript-repair.ts` | New `MissingToolResultPolicy` type, `shouldDropOrphanToolCalls` helper, and branching logic in `repairToolUseResultPairing` |
| `src/agents/compaction.ts` | Pass `{ missingToolResultPolicy: "drop-tool-call" }` at line ~547 |
| `src/agents/pi-hooks/compaction-safeguard.ts` | Pass `{ missingToolResultPolicy: "drop-tool-call" }` at line ~647 |
| `src/agents/session-transcript-repair.test.ts` | 6 new tests covering drop-tool-call policy edge cases |

## Test Results
- `session-transcript-repair.test.ts`: **39/39 pass** (6 new + 33 existing)
- `compaction.test.ts`: **34/34 pass**
- `compaction-safeguard.test.ts`: **172/172 pass**
- Type-check: **0 errors** in changed files

## Test Plan
- [x] Orphan tool calls stripped from mixed content (text + orphan tool call)
- [x] Entire assistant message dropped when all tool calls orphaned (no other content)
- [x] Mixed turns: only orphaned calls stripped, surviving calls preserved with results
- [x] Non-tool-call content preserved when stripping orphan calls
- [x] Default policy (no option) still synthesizes error results
- [x] Explicit `"synthesize-error"` policy still synthesizes error results

Closes #43