### PR TITLE
fix: restore injectHeartbeatPrompt default to prevent MiniMax API error 2013

### DIFF
--- a/src/agents/pi-embedded-runner/run/trigger-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/trigger-policy.test.ts
@@ -12,11 +12,19 @@ describe("shouldInjectHeartbeatPromptForTrigger", () => {
     ["cron"] as const,
     ["memory"] as const,
     ["overflow"] as const,
-  ])("does not inject the heartbeat prompt on %s-triggered runs", (trigger) => {
-    expect(shouldInjectHeartbeatPromptForTrigger(trigger)).toBe(false);
+  ])("injects the heartbeat prompt on %s-triggered runs (default policy)", (trigger) => {
+    expect(shouldInjectHeartbeatPromptForTrigger(trigger)).toBe(true);
   });
 
-  it("does not inject the heartbeat prompt when no trigger is supplied", () => {
-    expect(shouldInjectHeartbeatPromptForTrigger(undefined)).toBe(false);
+  it("injects the heartbeat prompt when no trigger is supplied (default policy)", () => {
+    expect(shouldInjectHeartbeatPromptForTrigger(undefined)).toBe(true);
+  });
+
+  it("defaults to injecting heartbeat prompt to prevent empty content on new sessions (regression: #47)", () => {
+    // Regression guard: changing this default to false causes MiniMax API error 2013
+    // 'chat content is empty' on new sessions with non-heartbeat triggers.
+    // See: https://github.com/yanbinwa/public-repo-openclaw/issues/47
+    expect(shouldInjectHeartbeatPromptForTrigger("user")).toBe(true);
+    expect(shouldInjectHeartbeatPromptForTrigger(undefined)).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-runner/run/trigger-policy.ts
+++ b/src/agents/pi-embedded-runner/run/trigger-policy.ts
@@ -5,7 +5,7 @@ type EmbeddedRunTriggerPolicy = {
 };
 
 const DEFAULT_EMBEDDED_RUN_TRIGGER_POLICY: EmbeddedRunTriggerPolicy = {
-  injectHeartbeatPrompt: false,
+  injectHeartbeatPrompt: true,
 };
 
 const EMBEDDED_RUN_TRIGGER_POLICY: Partial<Record<EmbeddedRunTrigger, EmbeddedRunTriggerPolicy>> = {


### PR DESCRIPTION
## Bug
- **Symptom**: MiniMax API error 2013 'chat content is empty' on new sessions with non-heartbeat triggers (user, manual, Feishu session reset)
- **Root cause**: `DEFAULT_EMBEDDED_RUN_TRIGGER_POLICY.injectHeartbeatPrompt` was changed from `true` to `false` between v2026.4.23 and v2026.4.25-beta.10, causing empty user messages to be sent to MiniMax

## Fix
- Restored `injectHeartbeatPrompt: true` as the default in `trigger-policy.ts`, matching v2026.4.23 behavior
- Updated test expectations to reflect the restored default
- Added regression test with issue reference (`#47`) to prevent future regressions

## Verification
- `trigger-policy.test.ts`: 8/8 passed (7 updated + 1 new regression test)
- `attempt.prompt-helpers.test.ts`: 16/16 passed (unchanged — non-regression confirmed)
- TypeScript compilation: pre-existing `@anthropic-ai/sdk` type errors only (unrelated)

Closes #47