### PR TITLE
fix: propagate dmPolicy in monitor cfg to prevent allowlist bypass on reconnect

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -166,6 +166,7 @@ export async function monitorWebChannel(
       ...baseCfg.channels,
       whatsapp: {
         ...baseCfg.channels?.whatsapp,
+        dmPolicy: account.dmPolicy,
         ackReaction: account.ackReaction,
         messagePrefix: account.messagePrefix,
         allowFrom: account.allowFrom,

--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -262,3 +262,97 @@ describe("WhatsApp dmPolicy precedence", () => {
     expect(result.isSelfChat).toBe(true);
   });
 });
+
+describe("dmPolicy allowlist survives monitor cfg override (#44)", () => {
+  it("blocks non-allowed sender when dmPolicy is flattened into channel config", async () => {
+    // Simulates the cfg object built by monitorWebChannel (auto-reply/monitor.ts)
+    // where account-level fields are spread directly into channels.whatsapp.
+    // Before the fix, dmPolicy was missing from this override, causing it to
+    // default to "pairing" and allowing queued messages through after reconnection.
+    const cfg = {
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          allowFrom: ["+15559999999"],
+        },
+      },
+    };
+    setAccessControlTestConfig(cfg);
+
+    const result = await checkInboundAccessControl({
+      cfg: getAccessControlTestConfig() as never,
+      accountId: "default",
+      from: "+15550001111",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: false,
+      pushName: "Stranger",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550001111@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(false);
+    // In allowlist mode, no pairing reply should be sent
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("allows listed sender when dmPolicy=allowlist is in channel config", async () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          allowFrom: ["+15550001111"],
+        },
+      },
+    };
+    setAccessControlTestConfig(cfg);
+
+    const result = await checkInboundAccessControl({
+      cfg: getAccessControlTestConfig() as never,
+      accountId: "default",
+      from: "+15550001111",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: false,
+      pushName: "Allowed",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550001111@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("does not read pairing store when dmPolicy=allowlist after reconnect", async () => {
+    // After reconnection, the monitor rebuilds the cfg with dmPolicy from account.
+    // Pairing store must NOT be consulted in allowlist mode.
+    const cfg = {
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          allowFrom: ["+15559999999"],
+        },
+      },
+    };
+    setAccessControlTestConfig(cfg);
+    readAllowFromStoreMock.mockResolvedValue(["+15550001111"]);
+
+    const result = await checkInboundAccessControl({
+      cfg: getAccessControlTestConfig() as never,
+      accountId: "default",
+      from: "+15550001111",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: false,
+      pushName: "PairedButNotAllowed",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550001111@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(readAllowFromStoreMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #44 — WhatsApp dmPolicy allowlist bypassed during gateway reconnection.

- **Root cause**: `monitorWebChannel` builds a `cfg` override that flattens account-level WhatsApp settings into `channels.whatsapp`. This override included `allowFrom`, `groupAllowFrom`, and `groupPolicy` but was **missing `dmPolicy`**. After a 408 gateway disconnect and reconnection, the omitted `dmPolicy` caused `resolveWhatsAppInboundPolicy` to default to `"pairing"` instead of `"allowlist"`, allowing queued messages from non-allowed contacts to be delivered to the agent.
- **Fix**: Add `dmPolicy: account.dmPolicy` to the cfg override in `extensions/whatsapp/src/auto-reply/monitor.ts`
- **Tests**: 3 regression tests verifying allowlist enforcement when dmPolicy is flattened into channel config

## Changes

| File | Change |
|------|--------|
| `extensions/whatsapp/src/auto-reply/monitor.ts` | Add missing `dmPolicy` to cfg override |
| `extensions/whatsapp/src/inbound/access-control.test.ts` | 3 regression tests for issue #44 |

## Test plan

- [x] All 11 access control tests pass (including 3 new)
- [ ] Verify with manual WhatsApp reconnection test: configure `dmPolicy: "allowlist"` with specific `allowFrom` numbers, trigger a gateway disconnect (408), confirm queued messages from non-allowed contacts are still blocked after reconnection