### PR TITLE
fix: prevent bonjour mDNS from blocking gateway startup

### DIFF
--- a/extensions/bonjour/openclaw.plugin.json
+++ b/extensions/bonjour/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "activation": {
     "onStartup": true
   },
-  "enabledByDefault": true,
+  "enabledByDefault": false,
   "name": "Bonjour Gateway Discovery",
   "description": "Advertise the local OpenClaw gateway over Bonjour/mDNS.",
   "configSchema": {

--- a/src/gateway/server-discovery-runtime.test.ts
+++ b/src/gateway/server-discovery-runtime.test.ts
@@ -114,10 +114,53 @@ describe("startGatewayDiscovery", () => {
       minimal: false,
     });
     expect(peer.service.advertise).toHaveBeenCalledTimes(1);
-    expect(logs.warn).not.toHaveBeenCalled();
 
+    // bonjourStop awaits the pending advertise promises, then calls stop in
+    // reverse order.
     await result.bonjourStop?.();
     expect(stopped).toEqual(["peer", "bonjour"]);
+    expect(logs.warn).not.toHaveBeenCalled();
+  });
+
+  it("does not block startup when a discovery service advertise is slow", async () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.VITEST;
+
+    let resolveAdvertise!: (value: { stop: () => void }) => void;
+    const slowAdvertise = new Promise<{ stop: () => void }>((resolve) => {
+      resolveAdvertise = resolve;
+    });
+    const stopped: string[] = [];
+    const slowService = makeDiscoveryService({
+      id: "slow-mdns",
+      pluginId: "slow-mdns",
+      advertise: vi.fn(() => slowAdvertise),
+    });
+    const logs = makeLogs();
+
+    // startGatewayDiscovery must return immediately even though advertise
+    // has not resolved — this is the critical non-blocking guarantee.
+    const result = await startGatewayDiscovery({
+      machineDisplayName: "Lab Mac",
+      port: 18789,
+      wideAreaDiscoveryEnabled: false,
+      tailscaleMode: "off",
+      mdnsMode: "minimal",
+      gatewayDiscoveryServices: [slowService],
+      logDiscovery: logs,
+    });
+
+    expect(result.bonjourStop).not.toBeNull();
+    expect(logs.warn).not.toHaveBeenCalled();
+
+    // Now resolve the slow advertise and verify stop works.
+    resolveAdvertise({
+      stop: () => {
+        stopped.push("slow-mdns");
+      },
+    });
+    await result.bonjourStop?.();
+    expect(stopped).toEqual(["slow-mdns"]);
   });
 
   it("skips local discovery services when mDNS mode is off", async () => {

--- a/src/gateway/server-discovery-runtime.ts
+++ b/src/gateway/server-discovery-runtime.ts
@@ -41,10 +41,17 @@ export async function startGatewayDiscovery(params: {
   const cliPath = mdnsMinimal ? undefined : resolveBonjourCliPath();
 
   if (localDiscoveryEnabled) {
-    const stops: Array<() => void | Promise<void>> = [];
+    // Discovery advertisement is intentionally non-blocking: mDNS probing can
+    // take 12-20+ seconds on some networks and must never delay gateway
+    // readiness.  Each service is started in the background; failures are
+    // logged but do not propagate.  See https://github.com/yanbinwa/public-repo-openclaw/issues/46
+    const pendingStops: Array<{
+      id: string;
+      started: Promise<{ stop?: () => void | Promise<void> } | void>;
+    }> = [];
     for (const entry of params.gatewayDiscoveryServices ?? []) {
-      try {
-        const started = await entry.service.advertise({
+      const started = entry.service
+        .advertise({
           machineDisplayName: params.machineDisplayName,
           gatewayPort: params.port,
           gatewayTlsEnabled: params.gatewayTls?.enabled ?? false,
@@ -54,23 +61,26 @@ export async function startGatewayDiscovery(params: {
           tailnetDns,
           cliPath,
           minimal: mdnsMinimal,
+        })
+        .catch((err: unknown) => {
+          params.logDiscovery.warn(
+            `gateway discovery service failed (${entry.service.id}, plugin=${entry.pluginId}): ${String(err)}`,
+          );
         });
-        if (started?.stop) {
-          stops.push(started.stop);
-        }
-      } catch (err) {
-        params.logDiscovery.warn(
-          `gateway discovery service failed (${entry.service.id}, plugin=${entry.pluginId}): ${String(err)}`,
-        );
-      }
+      pendingStops.push({ id: entry.service.id, started });
     }
-    if (stops.length > 0) {
+    if (pendingStops.length > 0) {
       bonjourStop = async () => {
-        for (const stop of stops.toReversed()) {
+        for (const pending of pendingStops.toReversed()) {
           try {
-            await stop();
+            const result = await pending.started;
+            if (result && typeof result === "object" && "stop" in result && result.stop) {
+              await result.stop();
+            }
           } catch (err) {
-            params.logDiscovery.warn(`gateway discovery stop failed: ${String(err)}`);
+            params.logDiscovery.warn(
+              `gateway discovery stop failed (${pending.id}): ${String(err)}`,
+            );
           }
         }
       };


### PR DESCRIPTION
## Summary

Fixes #46 — bonjour mDNS probing blocks gateway startup after 2026.4.26 upgrade, causing systemd timeout failures and ~75s delayed readiness.

**Root cause**: `enabledByDefault: true` in the bonjour plugin manifest combined with `await entry.service.advertise()` in the discovery startup path meant that slow mDNS probing (watchdog cycle: 3 × 20s stuck timeout) blocked the entire gateway startup pipeline.

**Changes**:
- Make bonjour plugin opt-in (`enabledByDefault: false`) so mDNS probing no longer runs automatically on fresh installs
- Make discovery advertisement non-blocking: `advertise()` calls are fire-and-forget promises so gateway readiness is never delayed by slow mDNS probing
- Add test verifying `startGatewayDiscovery` returns immediately even when advertise has not resolved

## Files changed
- `extensions/bonjour/openclaw.plugin.json` — `enabledByDefault: true` → `false`
- `src/gateway/server-discovery-runtime.ts` — non-blocking advertise pattern
- `src/gateway/server-discovery-runtime.test.ts` — updated + new non-blocking test

## Test plan
- [x] All 5 discovery runtime tests pass (including new non-blocking test)
- [ ] Manual verification: gateway starts within normal timeframe with bonjour disabled by default
- [ ] Manual verification: users who explicitly enable bonjour plugin still get mDNS discovery