### PR TITLE
fix: make context-engine assembly prompt-authoritative for overflow precheck

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1457,6 +1457,7 @@ export async function runEmbeddedAttempt(
       }
       let prePromptMessageCount = activeSession.messages.length;
       let unwindowedContextEngineMessagesForPrecheck: AgentMessage[] | undefined;
+      let contextEngineAssemblySucceeded = false;
       abortSessionForYield = () => {
         yieldAbortSettled = Promise.resolve(activeSession.abort());
       };
@@ -1991,6 +1992,7 @@ export async function runEmbeddedAttempt(
                 `context engine: prepended system prompt addition (${assembled.systemPromptAddition.length} chars)`,
               );
             }
+            contextEngineAssemblySucceeded = true;
           } catch (assembleErr) {
             log.warn(
               `context engine assemble failed, using pipeline messages: ${String(assembleErr)}`,
@@ -2621,6 +2623,7 @@ export async function runEmbeddedAttempt(
           const preemptiveCompaction = shouldPreemptivelyCompactBeforePrompt({
             messages: activeSession.messages,
             unwindowedMessages: unwindowedContextEngineMessagesForPrecheck,
+            assemblyIsPromptAuthoritative: contextEngineAssemblySucceeded,
             systemPrompt: systemPromptText,
             prompt: effectivePrompt,
             contextTokenBudget,

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -108,6 +108,43 @@ describe("preemptive-compaction", () => {
     expect(result.estimatedPromptTokens).toBeGreaterThan(result.promptBudgetBeforeReserve);
   });
 
+  it("allows prompt when assemblyIsPromptAuthoritative is true and assembled messages fit under budget", () => {
+    // Regression test for issue #39: context-engine assembled prompts must
+    // not be bypassed by the overflow precheck using pre-assembly history.
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [makeAssistantHistory("small assembled window")],
+      unwindowedMessages: [makeAssistantHistory(verboseHistory.repeat(4))],
+      assemblyIsPromptAuthoritative: true,
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: 10_000,
+      reserveTokens: 1_000,
+    });
+
+    // The assembled messages are small and fit easily — precheck should allow.
+    expect(result.shouldCompact).toBe(false);
+    expect(result.route).toBe("fits");
+    expect(result.estimatedPromptTokens).toBeLessThan(result.promptBudgetBeforeReserve);
+  });
+
+  it("still compacts when assemblyIsPromptAuthoritative is true but assembled messages themselves overflow", () => {
+    // Even with prompt-authoritative assembly, if the assembled view is still
+    // over budget, the precheck must still request compaction.
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [makeAssistantHistory(verboseHistory.repeat(4))],
+      unwindowedMessages: [makeAssistantHistory(verboseHistory.repeat(8))],
+      assemblyIsPromptAuthoritative: true,
+      systemPrompt: verboseSystem,
+      prompt: verbosePrompt,
+      contextTokenBudget: 500,
+      reserveTokens: 50,
+    });
+
+    expect(result.shouldCompact).toBe(true);
+    expect(result.route).toBe("compact_only");
+    expect(result.estimatedPromptTokens).toBeGreaterThan(result.promptBudgetBeforeReserve);
+  });
+
   it("caps reserve tokens so small context models keep usable prompt budget", () => {
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages: [makeAssistantHistory("short history")],

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -46,6 +46,13 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   contextTokenBudget: number;
   reserveTokens: number;
   toolResultMaxChars?: number;
+  /**
+   * When true, the context-engine assembled messages are treated as the
+   * prompt-authoritative view.  The precheck will NOT override the estimate
+   * with the larger unwindowed (pre-assembly) history, so a context engine
+   * that assembles a valid prompt under budget will not be bypassed.
+   */
+  assemblyIsPromptAuthoritative?: boolean;
 }): {
   route: PreemptiveCompactionRoute;
   shouldCompact: boolean;
@@ -61,7 +68,11 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     systemPrompt: params.systemPrompt,
     prompt: params.prompt,
   });
-  if (params.unwindowedMessages && params.unwindowedMessages !== params.messages) {
+  if (
+    params.unwindowedMessages &&
+    params.unwindowedMessages !== params.messages &&
+    !params.assemblyIsPromptAuthoritative
+  ) {
     const unwindowedEstimatedPromptTokens = estimatePrePromptTokens({
       messages: params.unwindowedMessages,
       systemPrompt: params.systemPrompt,


### PR DESCRIPTION
## Bug

- **Symptom**: Long-running context-engine sessions repeatedly hit preemptive overflow precheck, trigger compaction retries, and eventually reset the session — even when the context engine has already assembled a valid prompt-ready view under budget.
- **Root cause**: `shouldPreemptivelyCompactBeforePrompt()` unconditionally overrides the prompt estimate with the larger pre-assembly (`unwindowedMessages`) history. This bypasses the context-engine's assembly contract.

## Fix

- Added `assemblyIsPromptAuthoritative` parameter to `shouldPreemptivelyCompactBeforePrompt()`.
- When `true`, the precheck uses only the assembled messages for prompt admission and does NOT override with the unwindowed history estimate.
- The embedded runner (`attempt.ts`) now passes `assemblyIsPromptAuthoritative: true` when context-engine assembly succeeds.
- When assembly fails or no context engine is active, the existing behavior (using the larger estimate) is preserved.

## Verification

- 2 new regression tests added:
  1. Assembled messages under budget → precheck allows prompt (route=fits)
  2. Assembled messages over budget → precheck still compacts (route=compact_only)
- All 12 preemptive-compaction tests pass
- TypeScript type-check passes with no errors in modified files

Fixes #39