### PR TITLE
feat(tasks): normalize blocker and failure taxonomy

### DIFF
--- a/src/commands/status.summary.redaction.test.ts
+++ b/src/commands/status.summary.redaction.test.ts
@@ -49,6 +49,15 @@ describe("redactSensitiveStatusSummary", () => {
           cli: 0,
           cron: 1,
         },
+        byFailureClass: {
+          tool_runtime_error: 0,
+          provider_error: 0,
+          transport_error: 0,
+          config_error: 0,
+          timeout: 0,
+          interrupted: 0,
+          unknown_failure: 1,
+        },
       },
       taskAudit: {
         total: 1,
@@ -61,6 +70,15 @@ describe("redactSensitiveStatusSummary", () => {
           delivery_failed: 1,
           missing_cleanup: 0,
           inconsistent_timestamps: 0,
+        },
+        classifiedFailures: {
+          tool_runtime_error: 0,
+          provider_error: 0,
+          transport_error: 0,
+          config_error: 0,
+          timeout: 0,
+          interrupted: 0,
+          unknown_failure: 0,
         },
       },
       sessions: {

--- a/src/plugins/runtime/task-domain-types.ts
+++ b/src/plugins/runtime/task-domain-types.ts
@@ -9,6 +9,7 @@ import type {
   TaskStatusCounts,
   TaskTerminalOutcome,
 } from "../../tasks/task-registry.types.js";
+import type { TaskBlockerClass, TaskFailureClass } from "../../tasks/task-taxonomy.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 
 export type TaskRunAggregateSummary = {
@@ -46,6 +47,7 @@ export type TaskRunView = {
   progressSummary?: string;
   terminalSummary?: string;
   terminalOutcome?: TaskTerminalOutcome;
+  failureClass?: TaskFailureClass;
 };
 
 export type TaskRunDetail = TaskRunView;
@@ -66,6 +68,7 @@ export type TaskFlowView = {
   goal: string;
   currentStep?: string;
   cancelRequestedAt?: number;
+  blockerClass?: TaskBlockerClass;
   createdAt: number;
   updatedAt: number;
   endedAt?: number;

--- a/src/tasks/task-domain-views.ts
+++ b/src/tasks/task-domain-views.ts
@@ -47,6 +47,7 @@ export function mapTaskRunView(task: TaskRecord): TaskRunView {
     ...(task.progressSummary ? { progressSummary: task.progressSummary } : {}),
     ...(task.terminalSummary ? { terminalSummary: task.terminalSummary } : {}),
     ...(task.terminalOutcome ? { terminalOutcome: task.terminalOutcome } : {}),
+    ...(task.failureClass ? { failureClass: task.failureClass } : {}),
   };
 }
 
@@ -64,6 +65,7 @@ export function mapTaskFlowView(flow: TaskFlowRecord): TaskFlowView {
     goal: flow.goal,
     ...(flow.currentStep ? { currentStep: flow.currentStep } : {}),
     ...(flow.cancelRequestedAt !== undefined ? { cancelRequestedAt: flow.cancelRequestedAt } : {}),
+    ...(flow.blockerClass ? { blockerClass: flow.blockerClass } : {}),
     createdAt: flow.createdAt,
     updatedAt: flow.updatedAt,
     ...(flow.endedAt !== undefined ? { endedAt: flow.endedAt } : {}),

--- a/src/tasks/task-executor-policy.test.ts
+++ b/src/tasks/task-executor-policy.test.ts
@@ -97,7 +97,7 @@ describe("task-executor-policy", () => {
       "Task needs follow-up: Background task (run run-1234). Task is blocked and needs follow-up.",
     );
     expect(formatTaskTerminalMessage(failedTask)).toBe(
-      "Background task failed: Background task (run run-2234). Needs manual approval.",
+      "Background task failed (Error): Background task (run run-2234). Needs manual approval.",
     );
     expect(formatTaskStateChangeMessage(blockedTask, progressEvent)).toBeNull();
   });

--- a/src/tasks/task-executor-policy.ts
+++ b/src/tasks/task-executor-policy.ts
@@ -1,5 +1,6 @@
 import type { TaskEventRecord, TaskRecord, TaskStatus } from "./task-registry.types.js";
 import { formatTaskStatusTitleText, sanitizeTaskStatusText } from "./task-status.js";
+import { classifyTaskFailure, failureClassLabel } from "./task-taxonomy.js";
 
 export function isTerminalTaskStatus(status: TaskStatus): boolean {
   return (
@@ -55,11 +56,16 @@ export function formatTaskTerminalMessage(task: TaskRecord): string {
   }
   const error = sanitizeTaskStatusText(task.error, { errorContext: true });
   const fallbackSummary = sanitizeTaskStatusText(task.terminalSummary, { errorContext: true });
+  const cls = classifyTaskFailure(task);
+  const classLabel = cls ? failureClassLabel(cls) : undefined;
+  const failedPrefix = classLabel
+    ? `Background task failed (${classLabel})`
+    : "Background task failed";
   return error
-    ? `Background task failed: ${title}${runLabel}. ${error}`
+    ? `${failedPrefix}: ${title}${runLabel}. ${error}`
     : fallbackSummary
-      ? `Background task failed: ${title}${runLabel}. ${fallbackSummary}`
-      : `Background task failed: ${title}${runLabel}.`;
+      ? `${failedPrefix}: ${title}${runLabel}. ${fallbackSummary}`
+      : `${failedPrefix}: ${title}${runLabel}.`;
 }
 
 export function formatTaskBlockedFollowupMessage(task: TaskRecord): string | null {

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -2,6 +2,8 @@ import { listTasksForFlowId } from "./runtime-internal.js";
 import { getTaskFlowRegistryRestoreFailure, listTaskFlowRecords } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import type { TaskRecord } from "./task-registry.types.js";
+import type { TaskBlockerClass, TaskBlockerClassCounts } from "./task-taxonomy.js";
+import { classifyTaskBlocker, createEmptyBlockerClassCounts } from "./task-taxonomy.js";
 
 export type TaskFlowAuditSeverity = "warn" | "error";
 export type TaskFlowAuditCode =
@@ -20,6 +22,7 @@ export type TaskFlowAuditFinding = {
   detail: string;
   ageMs?: number;
   flow?: TaskFlowRecord;
+  blockerClass?: TaskBlockerClass;
 };
 
 export type TaskFlowAuditSummary = {
@@ -27,6 +30,7 @@ export type TaskFlowAuditSummary = {
   warnings: number;
   errors: number;
   byCode: Record<TaskFlowAuditCode, number>;
+  classifiedBlockers: TaskBlockerClassCounts;
 };
 
 export type TaskFlowAuditOptions = {
@@ -50,12 +54,20 @@ function createFinding(params: {
   ageMs?: number;
   flow?: TaskFlowRecord;
 }): TaskFlowAuditFinding {
+  const blockerClass =
+    params.flow?.status === "blocked"
+      ? classifyTaskBlocker({
+          blockedSummary: params.flow.blockedSummary,
+          blockerClass: params.flow.blockerClass,
+        })
+      : undefined;
   return {
     severity: params.severity,
     code: params.code,
     detail: params.detail,
     ...(typeof params.ageMs === "number" ? { ageMs: params.ageMs } : {}),
     ...(params.flow ? { flow: params.flow } : {}),
+    ...(blockerClass ? { blockerClass } : {}),
   };
 }
 
@@ -133,6 +145,7 @@ export function createEmptyTaskFlowAuditSummary(): TaskFlowAuditSummary {
       blocked_task_missing: 0,
       inconsistent_timestamps: 0,
     },
+    classifiedBlockers: createEmptyBlockerClassCounts(),
   };
 }
 
@@ -280,6 +293,9 @@ export function summarizeTaskFlowAuditFindings(
       summary.errors += 1;
     } else {
       summary.warnings += 1;
+    }
+    if (finding.blockerClass) {
+      summary.classifiedBlockers[finding.blockerClass] += 1;
     }
   }
   return summary;

--- a/src/tasks/task-flow-registry.types.ts
+++ b/src/tasks/task-flow-registry.types.ts
@@ -1,5 +1,6 @@
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import type { TaskNotifyPolicy } from "./task-registry.types.js";
+import type { TaskBlockerClass } from "./task-taxonomy.js";
 
 export type JsonValue =
   | null
@@ -34,6 +35,7 @@ export type TaskFlowRecord = {
   currentStep?: string;
   blockedTaskId?: string;
   blockedSummary?: string;
+  blockerClass?: TaskBlockerClass;
   stateJson?: JsonValue;
   waitJson?: JsonValue;
   cancelRequestedAt?: number;

--- a/src/tasks/task-registry.audit.shared.ts
+++ b/src/tasks/task-registry.audit.shared.ts
@@ -1,4 +1,6 @@
 import type { TaskRecord } from "./task-registry.types.js";
+import type { TaskFailureClass, TaskFailureClassCounts } from "./task-taxonomy.js";
+import { createEmptyFailureClassCounts } from "./task-taxonomy.js";
 
 export type TaskAuditSeverity = "warn" | "error";
 export type TaskAuditCode =
@@ -15,6 +17,7 @@ export type TaskAuditFinding = {
   task: TaskRecord;
   ageMs?: number;
   detail: string;
+  failureClass?: TaskFailureClass;
 };
 
 export type TaskAuditSummary = {
@@ -22,6 +25,7 @@ export type TaskAuditSummary = {
   warnings: number;
   errors: number;
   byCode: Record<TaskAuditCode, number>;
+  classifiedFailures: TaskFailureClassCounts;
 };
 
 type TaskAuditComparableFinding = {
@@ -43,6 +47,7 @@ export function createEmptyTaskAuditSummary(): TaskAuditSummary {
       missing_cleanup: 0,
       inconsistent_timestamps: 0,
     },
+    classifiedFailures: createEmptyFailureClassCounts(),
   };
 }
 

--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -80,6 +80,15 @@ describe("task-registry audit", () => {
         missing_cleanup: 0,
         inconsistent_timestamps: 0,
       },
+      classifiedFailures: {
+        tool_runtime_error: 0,
+        provider_error: 0,
+        transport_error: 0,
+        config_error: 0,
+        timeout: 0,
+        interrupted: 0,
+        unknown_failure: 0,
+      },
     });
   });
 

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -7,6 +7,7 @@ import {
   type TaskAuditSummary,
 } from "./task-registry.audit.shared.js";
 import type { TaskRecord } from "./task-registry.types.js";
+import { classifyTaskFailure } from "./task-taxonomy.js";
 
 export type TaskAuditOptions = {
   now?: number;
@@ -33,12 +34,14 @@ function createFinding(params: {
   detail: string;
   ageMs?: number;
 }): TaskAuditFinding {
+  const failureClass = classifyTaskFailure(params.task);
   return {
     severity: params.severity,
     code: params.code,
     task: params.task,
     detail: params.detail,
     ...(typeof params.ageMs === "number" ? { ageMs: params.ageMs } : {}),
+    ...(failureClass ? { failureClass } : {}),
   };
 }
 
@@ -187,6 +190,9 @@ export function summarizeTaskAuditFindings(findings: Iterable<TaskAuditFinding>)
       summary.errors += 1;
     } else {
       summary.warnings += 1;
+    }
+    if (finding.failureClass) {
+      summary.classifiedFailures[finding.failureClass] += 1;
     }
   }
   return summary;

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -34,6 +34,7 @@ type TaskRegistryRow = {
   progress_summary: string | null;
   terminal_summary: string | null;
   terminal_outcome: TaskRecord["terminalOutcome"] | null;
+  failure_class: TaskRecord["failureClass"] | null;
 };
 
 type TaskDeliveryStateRow = {
@@ -126,6 +127,7 @@ function rowToTaskRecord(row: TaskRegistryRow): TaskRecord {
     ...(row.progress_summary ? { progressSummary: row.progress_summary } : {}),
     ...(row.terminal_summary ? { terminalSummary: row.terminal_summary } : {}),
     ...(row.terminal_outcome ? { terminalOutcome: row.terminal_outcome } : {}),
+    ...(row.failure_class ? { failureClass: row.failure_class } : {}),
   };
 }
 
@@ -167,6 +169,7 @@ function bindTaskRecordBase(record: TaskRecord) {
     progress_summary: record.progressSummary ?? null,
     terminal_summary: record.terminalSummary ?? null,
     terminal_outcome: record.terminalOutcome ?? null,
+    failure_class: record.failureClass ?? null,
   };
 }
 
@@ -207,7 +210,8 @@ function createStatements(db: DatabaseSync): TaskRegistryStatements {
         error,
         progress_summary,
         terminal_summary,
-        terminal_outcome
+        terminal_outcome,
+        failure_class
       FROM task_runs
       ORDER BY created_at ASC, task_id ASC
     `),
@@ -246,7 +250,8 @@ function createStatements(db: DatabaseSync): TaskRegistryStatements {
         error,
         progress_summary,
         terminal_summary,
-        terminal_outcome
+        terminal_outcome,
+        failure_class
       ) VALUES (
         @task_id,
         @runtime,
@@ -273,7 +278,8 @@ function createStatements(db: DatabaseSync): TaskRegistryStatements {
         @error,
         @progress_summary,
         @terminal_summary,
-        @terminal_outcome
+        @terminal_outcome,
+        @failure_class
       )
       ON CONFLICT(task_id) DO UPDATE SET
         runtime = excluded.runtime,
@@ -300,7 +306,8 @@ function createStatements(db: DatabaseSync): TaskRegistryStatements {
         error = excluded.error,
         progress_summary = excluded.progress_summary,
         terminal_summary = excluded.terminal_summary,
-        terminal_outcome = excluded.terminal_outcome
+        terminal_outcome = excluded.terminal_outcome,
+        failure_class = excluded.failure_class
     `),
     replaceDeliveryState: db.prepare(`
       INSERT OR REPLACE INTO task_delivery_state (
@@ -404,6 +411,9 @@ function ensureSchema(db: DatabaseSync) {
   }
   if (!hasTaskRunsColumn(db, "parent_flow_id")) {
     db.exec(`ALTER TABLE task_runs ADD COLUMN parent_flow_id TEXT;`);
+  }
+  if (!hasTaskRunsColumn(db, "failure_class")) {
+    db.exec(`ALTER TABLE task_runs ADD COLUMN failure_class TEXT;`);
   }
   db.exec(`
     CREATE TABLE IF NOT EXISTS task_delivery_state (

--- a/src/tasks/task-registry.summary.ts
+++ b/src/tasks/task-registry.summary.ts
@@ -4,6 +4,7 @@ import type {
   TaskRuntimeCounts,
   TaskStatusCounts,
 } from "./task-registry.types.js";
+import { classifyTaskFailure, createEmptyFailureClassCounts } from "./task-taxonomy.js";
 
 function createEmptyTaskStatusCounts(): TaskStatusCounts {
   return {
@@ -34,6 +35,7 @@ export function createEmptyTaskRegistrySummary(): TaskRegistrySummary {
     failures: 0,
     byStatus: createEmptyTaskStatusCounts(),
     byRuntime: createEmptyTaskRuntimeCounts(),
+    byFailureClass: createEmptyFailureClassCounts(),
   };
 }
 
@@ -50,6 +52,10 @@ export function summarizeTaskRecords(records: Iterable<TaskRecord>): TaskRegistr
     }
     if (task.status === "failed" || task.status === "timed_out" || task.status === "lost") {
       summary.failures += 1;
+      const failureClass = classifyTaskFailure(task);
+      if (failureClass) {
+        summary.byFailureClass[failureClass] += 1;
+      }
     }
   }
   return summary;

--- a/src/tasks/task-registry.types.ts
+++ b/src/tasks/task-registry.types.ts
@@ -1,4 +1,5 @@
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import type { TaskFailureClass, TaskFailureClassCounts } from "./task-taxonomy.js";
 
 export type TaskRuntime = "subagent" | "acp" | "cli" | "cron";
 
@@ -34,6 +35,7 @@ export type TaskRegistrySummary = {
   failures: number;
   byStatus: TaskStatusCounts;
   byRuntime: TaskRuntimeCounts;
+  byFailureClass: TaskFailureClassCounts;
 };
 
 export type TaskEventKind = TaskStatus | "progress";
@@ -77,6 +79,7 @@ export type TaskRecord = {
   progressSummary?: string;
   terminalSummary?: string;
   terminalOutcome?: TaskTerminalOutcome;
+  failureClass?: TaskFailureClass;
 };
 
 export type TaskRegistrySnapshot = {

--- a/src/tasks/task-taxonomy.test.ts
+++ b/src/tasks/task-taxonomy.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import type { TaskRecord } from "./task-registry.types.js";
+import {
+  TASK_BLOCKER_CLASSES,
+  TASK_FAILURE_CLASSES,
+  blockerClassLabel,
+  classifyTaskBlocker,
+  classifyTaskFailure,
+  createEmptyBlockerClassCounts,
+  createEmptyFailureClassCounts,
+  failureClassLabel,
+  isRetryableFailure,
+  isTransientFailure,
+} from "./task-taxonomy.js";
+
+function createTask(partial: Partial<TaskRecord>): TaskRecord {
+  return {
+    taskId: partial.taskId ?? "task-1",
+    runtime: partial.runtime ?? "acp",
+    requesterSessionKey: partial.requesterSessionKey ?? "agent:main:main",
+    ownerKey: partial.ownerKey ?? "agent:main:main",
+    scopeKind: partial.scopeKind ?? "session",
+    task: partial.task ?? "Background task",
+    status: partial.status ?? "queued",
+    deliveryStatus: partial.deliveryStatus ?? "pending",
+    notifyPolicy: partial.notifyPolicy ?? "done_only",
+    createdAt: partial.createdAt ?? 1,
+    ...partial,
+  };
+}
+
+describe("task-taxonomy", () => {
+  describe("classifyTaskFailure", () => {
+    it("returns undefined for non-failure statuses", () => {
+      expect(classifyTaskFailure(createTask({ status: "queued" }))).toBeUndefined();
+      expect(classifyTaskFailure(createTask({ status: "running" }))).toBeUndefined();
+      expect(classifyTaskFailure(createTask({ status: "succeeded" }))).toBeUndefined();
+      expect(classifyTaskFailure(createTask({ status: "cancelled" }))).toBeUndefined();
+    });
+
+    it("returns persisted failureClass when set", () => {
+      expect(
+        classifyTaskFailure(
+          createTask({ status: "failed", failureClass: "config_error", error: "timeout" }),
+        ),
+      ).toBe("config_error");
+    });
+
+    it("classifies timed_out status as timeout", () => {
+      expect(classifyTaskFailure(createTask({ status: "timed_out" }))).toBe("timeout");
+    });
+
+    it("classifies timeout-related errors", () => {
+      expect(
+        classifyTaskFailure(createTask({ status: "failed", error: "Request timed out" })),
+      ).toBe("timeout");
+      expect(
+        classifyTaskFailure(createTask({ status: "failed", error: "deadline exceeded" })),
+      ).toBe("timeout");
+    });
+
+    it("classifies transport errors", () => {
+      expect(classifyTaskFailure(createTask({ status: "failed", error: "ECONNREFUSED" }))).toBe(
+        "transport_error",
+      );
+      expect(classifyTaskFailure(createTask({ status: "failed", error: "fetch failed" }))).toBe(
+        "transport_error",
+      );
+      expect(classifyTaskFailure(createTask({ status: "failed", error: "socket hang up" }))).toBe(
+        "transport_error",
+      );
+    });
+
+    it("classifies provider errors", () => {
+      expect(classifyTaskFailure(createTask({ status: "failed", error: "rate limit hit" }))).toBe(
+        "provider_error",
+      );
+      expect(classifyTaskFailure(createTask({ status: "failed", error: "HTTP 429" }))).toBe(
+        "provider_error",
+      );
+      expect(
+        classifyTaskFailure(createTask({ status: "failed", error: "service unavailable" })),
+      ).toBe("provider_error");
+    });
+
+    it("classifies config errors", () => {
+      expect(
+        classifyTaskFailure(createTask({ status: "failed", error: "permission denied" })),
+      ).toBe("config_error");
+      expect(classifyTaskFailure(createTask({ status: "failed", error: "unauthorized 401" }))).toBe(
+        "config_error",
+      );
+    });
+
+    it("classifies tool runtime errors", () => {
+      expect(
+        classifyTaskFailure(createTask({ status: "failed", error: "tool execution error" })),
+      ).toBe("tool_runtime_error");
+      expect(classifyTaskFailure(createTask({ status: "failed", error: "sandbox crashed" }))).toBe(
+        "tool_runtime_error",
+      );
+    });
+
+    it("classifies interrupted errors", () => {
+      expect(
+        classifyTaskFailure(createTask({ status: "failed", error: "process interrupted" })),
+      ).toBe("interrupted");
+      expect(classifyTaskFailure(createTask({ status: "failed", error: "gateway restart" }))).toBe(
+        "interrupted",
+      );
+    });
+
+    it("falls back to unknown_failure", () => {
+      expect(classifyTaskFailure(createTask({ status: "failed", error: "something weird" }))).toBe(
+        "unknown_failure",
+      );
+      expect(classifyTaskFailure(createTask({ status: "failed" }))).toBe("unknown_failure");
+    });
+
+    it("classifies lost tasks", () => {
+      expect(classifyTaskFailure(createTask({ status: "lost" }))).toBe("unknown_failure");
+      expect(classifyTaskFailure(createTask({ status: "lost", error: "ECONNRESET" }))).toBe(
+        "transport_error",
+      );
+    });
+  });
+
+  describe("classifyTaskBlocker", () => {
+    it("returns persisted blockerClass when set", () => {
+      expect(
+        classifyTaskBlocker({
+          blockerClass: "approval_required",
+          blockedSummary: "something else",
+        }),
+      ).toBe("approval_required");
+    });
+
+    it("classifies approval-related summaries", () => {
+      expect(classifyTaskBlocker({ blockedSummary: "Needs approval from admin" })).toBe(
+        "approval_required",
+      );
+      expect(classifyTaskBlocker({ blockedSummary: "Requires authorization" })).toBe(
+        "approval_required",
+      );
+    });
+
+    it("falls back to external_wait", () => {
+      expect(classifyTaskBlocker({ blockedSummary: "waiting for deploy" })).toBe("external_wait");
+      expect(classifyTaskBlocker({})).toBe("external_wait");
+    });
+  });
+
+  describe("predicates", () => {
+    it("isRetryableFailure returns true for retryable classes", () => {
+      expect(isRetryableFailure("transport_error")).toBe(true);
+      expect(isRetryableFailure("provider_error")).toBe(true);
+      expect(isRetryableFailure("timeout")).toBe(true);
+      expect(isRetryableFailure("config_error")).toBe(false);
+      expect(isRetryableFailure("tool_runtime_error")).toBe(false);
+      expect(isRetryableFailure("interrupted")).toBe(false);
+      expect(isRetryableFailure("unknown_failure")).toBe(false);
+    });
+
+    it("isTransientFailure returns true for transient classes", () => {
+      expect(isTransientFailure("transport_error")).toBe(true);
+      expect(isTransientFailure("timeout")).toBe(true);
+      expect(isTransientFailure("provider_error")).toBe(false);
+    });
+  });
+
+  describe("labels", () => {
+    it("returns human-readable labels for all failure classes", () => {
+      for (const cls of TASK_FAILURE_CLASSES) {
+        expect(typeof failureClassLabel(cls)).toBe("string");
+        expect(failureClassLabel(cls).length).toBeGreaterThan(0);
+      }
+    });
+
+    it("returns human-readable labels for all blocker classes", () => {
+      for (const cls of TASK_BLOCKER_CLASSES) {
+        expect(typeof blockerClassLabel(cls)).toBe("string");
+        expect(blockerClassLabel(cls).length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("count factories", () => {
+    it("createEmptyFailureClassCounts has a key for every failure class", () => {
+      const counts = createEmptyFailureClassCounts();
+      for (const cls of TASK_FAILURE_CLASSES) {
+        expect(counts[cls]).toBe(0);
+      }
+    });
+
+    it("createEmptyBlockerClassCounts has a key for every blocker class", () => {
+      const counts = createEmptyBlockerClassCounts();
+      for (const cls of TASK_BLOCKER_CLASSES) {
+        expect(counts[cls]).toBe(0);
+      }
+    });
+  });
+});

--- a/src/tasks/task-taxonomy.ts
+++ b/src/tasks/task-taxonomy.ts
@@ -1,0 +1,277 @@
+/**
+ * Shared blocker/failure taxonomy for the task system.
+ *
+ * Centralizes machine-readable classification of *why* a task is blocked or
+ * failed so that audits, summaries, user-facing messages, and future retry
+ * logic can all use the same vocabulary.
+ */
+
+import type { TaskRecord } from "./task-registry.types.js";
+
+// ---------------------------------------------------------------------------
+// Failure classes — why a task ended in a failure state
+// ---------------------------------------------------------------------------
+
+export type TaskFailureClass =
+  | "tool_runtime_error"
+  | "provider_error"
+  | "transport_error"
+  | "config_error"
+  | "timeout"
+  | "interrupted"
+  | "unknown_failure";
+
+export const TASK_FAILURE_CLASSES: readonly TaskFailureClass[] = [
+  "tool_runtime_error",
+  "provider_error",
+  "transport_error",
+  "config_error",
+  "timeout",
+  "interrupted",
+  "unknown_failure",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Blocker classes — why a task/flow is blocked
+// ---------------------------------------------------------------------------
+
+export type TaskBlockerClass = "approval_required" | "external_wait";
+
+export const TASK_BLOCKER_CLASSES: readonly TaskBlockerClass[] = [
+  "approval_required",
+  "external_wait",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Predicate helpers — enable retry logic without bespoke heuristics
+// ---------------------------------------------------------------------------
+
+const RETRYABLE_FAILURES = new Set<TaskFailureClass>([
+  "transport_error",
+  "provider_error",
+  "timeout",
+]);
+
+const TRANSIENT_FAILURES = new Set<TaskFailureClass>(["transport_error", "timeout"]);
+
+export function isRetryableFailure(cls: TaskFailureClass): boolean {
+  return RETRYABLE_FAILURES.has(cls);
+}
+
+export function isTransientFailure(cls: TaskFailureClass): boolean {
+  return TRANSIENT_FAILURES.has(cls);
+}
+
+// ---------------------------------------------------------------------------
+// Failure classification — derive class from a TaskRecord
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify why a task failed. Returns a `TaskFailureClass` for any task in
+ * a failure-like terminal state, or `undefined` for non-failure states.
+ *
+ * Priority:
+ * 1. If the task already carries a persisted `failureClass`, return it as-is.
+ * 2. Derive from `status` (e.g. `timed_out` → `timeout`).
+ * 3. Pattern-match the `error` string.
+ * 4. Fall back to `"unknown_failure"`.
+ */
+export function classifyTaskFailure(
+  task: Pick<TaskRecord, "status" | "error" | "failureClass">,
+): TaskFailureClass | undefined {
+  if (task.status !== "failed" && task.status !== "timed_out" && task.status !== "lost") {
+    return undefined;
+  }
+
+  if (task.failureClass) {
+    return task.failureClass;
+  }
+
+  if (task.status === "timed_out") {
+    return "timeout";
+  }
+
+  const error = task.error?.toLowerCase() ?? "";
+
+  if (matchesTimeout(error)) {
+    return "timeout";
+  }
+  if (matchesTransport(error)) {
+    return "transport_error";
+  }
+  if (matchesProvider(error)) {
+    return "provider_error";
+  }
+  if (matchesConfig(error)) {
+    return "config_error";
+  }
+  if (matchesToolRuntime(error)) {
+    return "tool_runtime_error";
+  }
+  if (matchesInterrupted(error)) {
+    return "interrupted";
+  }
+
+  return "unknown_failure";
+}
+
+// ---------------------------------------------------------------------------
+// Blocker classification — derive class from blocked metadata
+// ---------------------------------------------------------------------------
+
+export type BlockerClassificationInput = {
+  blockedSummary?: string;
+  blockerClass?: TaskBlockerClass;
+};
+
+/**
+ * Classify why a task or flow is blocked.
+ *
+ * Priority:
+ * 1. If `blockerClass` is already set, return it.
+ * 2. Pattern-match `blockedSummary`.
+ * 3. Fall back to `"external_wait"`.
+ */
+export function classifyTaskBlocker(input: BlockerClassificationInput): TaskBlockerClass {
+  if (input.blockerClass) {
+    return input.blockerClass;
+  }
+
+  const summary = input.blockedSummary?.toLowerCase() ?? "";
+
+  if (matchesApproval(summary)) {
+    return "approval_required";
+  }
+
+  return "external_wait";
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable label for user-facing messages
+// ---------------------------------------------------------------------------
+
+const FAILURE_LABELS: Record<TaskFailureClass, string> = {
+  tool_runtime_error: "Tool error",
+  provider_error: "Provider error",
+  transport_error: "Transport error",
+  config_error: "Configuration error",
+  timeout: "Timeout",
+  interrupted: "Interrupted",
+  unknown_failure: "Error",
+};
+
+const BLOCKER_LABELS: Record<TaskBlockerClass, string> = {
+  approval_required: "Approval required",
+  external_wait: "Waiting on external",
+};
+
+export function failureClassLabel(cls: TaskFailureClass): string {
+  return FAILURE_LABELS[cls];
+}
+
+export function blockerClassLabel(cls: TaskBlockerClass): string {
+  return BLOCKER_LABELS[cls];
+}
+
+// ---------------------------------------------------------------------------
+// Empty count maps for summaries
+// ---------------------------------------------------------------------------
+
+export type TaskFailureClassCounts = Record<TaskFailureClass, number>;
+export type TaskBlockerClassCounts = Record<TaskBlockerClass, number>;
+
+export function createEmptyFailureClassCounts(): TaskFailureClassCounts {
+  return {
+    tool_runtime_error: 0,
+    provider_error: 0,
+    transport_error: 0,
+    config_error: 0,
+    timeout: 0,
+    interrupted: 0,
+    unknown_failure: 0,
+  };
+}
+
+export function createEmptyBlockerClassCounts(): TaskBlockerClassCounts {
+  return {
+    approval_required: 0,
+    external_wait: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pattern helpers (private)
+// ---------------------------------------------------------------------------
+
+function matchesTimeout(error: string): boolean {
+  return (
+    error.includes("timed out") || error.includes("timeout") || error.includes("deadline exceeded")
+  );
+}
+
+function matchesTransport(error: string): boolean {
+  return (
+    error.includes("econnrefused") ||
+    error.includes("econnreset") ||
+    error.includes("enotfound") ||
+    error.includes("network") ||
+    error.includes("socket hang up") ||
+    error.includes("fetch failed") ||
+    error.includes("transport")
+  );
+}
+
+function matchesProvider(error: string): boolean {
+  return (
+    error.includes("provider") ||
+    error.includes("rate limit") ||
+    error.includes("429") ||
+    error.includes("503") ||
+    error.includes("502") ||
+    error.includes("service unavailable") ||
+    error.includes("quota exceeded") ||
+    error.includes("api error")
+  );
+}
+
+function matchesConfig(error: string): boolean {
+  return (
+    error.includes("config") ||
+    error.includes("invalid key") ||
+    error.includes("missing key") ||
+    error.includes("permission denied") ||
+    error.includes("unauthorized") ||
+    error.includes("forbidden") ||
+    error.includes("401") ||
+    error.includes("403")
+  );
+}
+
+function matchesToolRuntime(error: string): boolean {
+  return (
+    error.includes("tool") ||
+    error.includes("runtime error") ||
+    error.includes("execution error") ||
+    error.includes("sandbox")
+  );
+}
+
+function matchesInterrupted(error: string): boolean {
+  return (
+    error.includes("interrupted") ||
+    error.includes("cancelled") ||
+    error.includes("aborted") ||
+    error.includes("gateway restart")
+  );
+}
+
+function matchesApproval(summary: string): boolean {
+  return (
+    summary.includes("approval") ||
+    summary.includes("approve") ||
+    summary.includes("review") ||
+    summary.includes("permission") ||
+    summary.includes("authorize") ||
+    summary.includes("authorization")
+  );
+}


### PR DESCRIPTION
## Summary
- Introduces a shared `task-taxonomy.ts` module with `TaskFailureClass` (7 values) and `TaskBlockerClass` (2 values) type aliases, classifiers, predicates (`isRetryableFailure`, `isTransientFailure`), human-readable labels, and count factory functions
- Wires `failureClass` into `TaskRecord`, SQLite store (with `ALTER TABLE` migration), registry summary counts, audit findings/summary, domain views, and terminal message formatting
- Wires `blockerClass` into `TaskFlowRecord`, flow audit findings/summary, and flow domain views
- All new fields are optional for full backward compatibility

## Changed files
| File | Change |
|------|--------|
| `src/tasks/task-taxonomy.ts` | **New** — core taxonomy module |
| `src/tasks/task-taxonomy.test.ts` | **New** — 19 tests covering classifiers, predicates, labels, factories |
| `src/tasks/task-registry.types.ts` | Add `failureClass` to `TaskRecord`, `byFailureClass` to `TaskRegistrySummary` |
| `src/tasks/task-flow-registry.types.ts` | Add `blockerClass` to `TaskFlowRecord` |
| `src/tasks/task-registry.store.sqlite.ts` | Add `failure_class` column, migration, row mapping |
| `src/tasks/task-registry.summary.ts` | Count failures by class in `summarizeTaskRecords` |
| `src/tasks/task-registry.audit.shared.ts` | Add `failureClass` to finding, `classifiedFailures` to summary |
| `src/tasks/task-registry.audit.ts` | Derive `failureClass` in `createFinding`, count in `summarize` |
| `src/tasks/task-flow-registry.audit.ts` | Add `blockerClass` to finding, `classifiedBlockers` to summary |
| `src/tasks/task-domain-views.ts` | Expose `failureClass` in task views, `blockerClass` in flow views |
| `src/plugins/runtime/task-domain-types.ts` | Add `failureClass` to `TaskRunView`, `blockerClass` to `TaskFlowView` |
| `src/tasks/task-executor-policy.ts` | Classification-aware failure label in terminal messages |
| `src/tasks/task-registry.audit.test.ts` | Update assertions for `classifiedFailures` |
| `src/tasks/task-executor-policy.test.ts` | Update assertions for classification-aware formatting |

## Test plan
- [x] New `task-taxonomy.test.ts`: 19 tests covering all classifiers, predicates, labels, and factories
- [x] Updated `task-registry.audit.test.ts`: assertions include `classifiedFailures` counts
- [x] Updated `task-executor-policy.test.ts`: assertions match classification-aware terminal messages
- [x] All 29 tests pass (3 test files)

Closes #79