### PR TITLE
feat(tasks): add compressed operational summaries

### DIFF
--- a/src/auto-reply/reply/commands-tasks.ts
+++ b/src/auto-reply/reply/commands-tasks.ts
@@ -2,6 +2,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { logVerbose } from "../../globals.js";
 import { formatDurationCompact } from "../../infra/format-time/format-duration.ts";
 import { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
+import { buildTaskOpsSummary, formatTaskOpsSummary } from "../../tasks/task-ops-summary.js";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import {
   listTasksForAgentIdForStatus,
@@ -70,11 +71,13 @@ function formatVisibleTask(task: TaskRecord, index: number): string {
   const status = task.status.replaceAll("_", " ");
   const timing = formatTaskTiming(task);
   const detail = formatTaskDetail(task);
+  const opsSummary = formatTaskOpsSummary(buildTaskOpsSummary(task));
   const meta = [TASK_RUNTIME_LABELS[task.runtime], status, timing].filter(Boolean).join(" · ");
   const lines = [`${index + 1}. ${TASK_STATUS_ICONS[task.status]} ${title}`, `   ${meta}`];
   if (detail) {
     lines.push(`   ${detail}`);
   }
+  lines.push(`   ${opsSummary}`);
   return lines.join("\n");
 }
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -16,6 +16,7 @@ import {
   runTaskFlowRegistryMaintenance,
 } from "../tasks/task-flow-registry.maintenance.js";
 import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
+import { buildTaskOpsSummary, formatTaskOpsSummary } from "../tasks/task-ops-summary.js";
 import {
   listTaskAuditFindings,
   summarizeTaskAuditFindings,
@@ -362,6 +363,7 @@ export async function tasksShowCommand(
     ...(task.error ? [`error: ${task.error}`] : []),
     ...(task.progressSummary ? [`progressSummary: ${task.progressSummary}`] : []),
     ...(task.terminalSummary ? [`terminalSummary: ${task.terminalSummary}`] : []),
+    `opsSummary: ${formatTaskOpsSummary(buildTaskOpsSummary(task))}`,
   ];
   for (const line of lines) {
     runtime.log(line);

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -24,6 +24,7 @@ import {
   resolveUsageProviderId,
 } from "../infra/provider-usage.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import { buildTaskOpsSummary, formatTaskOpsSummary } from "../tasks/task-ops-summary.js";
 import {
   listTasksForAgentIdForStatus,
   listTasksForSessionKeyForStatus,
@@ -94,9 +95,8 @@ function formatSessionTaskLine(sessionKey: string): string | undefined {
       : snapshot.recentFailureCount > 0
         ? `${snapshot.recentFailureCount} recent failure${snapshot.recentFailureCount === 1 ? "" : "s"}`
         : "recently finished";
-  const title = formatTaskStatusTitle(task);
-  const detail = formatTaskStatusDetail(task);
-  const parts = [headline, task.runtime, title, detail].filter(Boolean);
+  const opsSummary = formatTaskOpsSummary(buildTaskOpsSummary(task));
+  const parts = [headline, task.runtime, opsSummary].filter(Boolean);
   return parts.length ? `📌 Tasks: ${parts.join(" · ")}` : undefined;
 }
 

--- a/src/tasks/task-ops-summary.test.ts
+++ b/src/tasks/task-ops-summary.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest";
+import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import { buildTaskOpsSummary, formatTaskOpsSummary } from "./task-ops-summary.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+const NOW = 1_000_000_000_000;
+
+function makeTask(overrides: Partial<TaskRecord>): TaskRecord {
+  return {
+    taskId: "task-1",
+    runId: "run-1",
+    task: "default task",
+    runtime: "subagent",
+    status: "running",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    createdAt: NOW - 1_000,
+    deliveryStatus: "pending",
+    notifyPolicy: "done_only",
+    ...overrides,
+  };
+}
+
+function makeFlow(overrides: Partial<TaskFlowRecord>): TaskFlowRecord {
+  return {
+    flowId: "flow-1",
+    syncMode: "managed",
+    ownerKey: "agent:main:main",
+    revision: 1,
+    status: "running",
+    notifyPolicy: "done_only",
+    goal: "test flow",
+    createdAt: NOW - 2_000,
+    updatedAt: NOW - 500,
+    ...overrides,
+  };
+}
+
+describe("buildTaskOpsSummary", () => {
+  it("AC-1: running task produces active state with checkpoint", () => {
+    const task = makeTask({
+      status: "running",
+      progressSummary: "compiling assets",
+    });
+
+    const summary = buildTaskOpsSummary(task);
+
+    expect(summary.state).toBe("active");
+    expect(summary.lastCheckpoint).toBe("compiling assets");
+    expect(summary.blocker).toBeUndefined();
+    expect(summary.nextAction).toBeUndefined();
+  });
+
+  it("AC-2: blocked task produces blocked state with blocker", () => {
+    const task = makeTask({
+      status: "succeeded",
+      terminalOutcome: "blocked",
+      terminalSummary: "awaiting approval",
+    });
+
+    const summary = buildTaskOpsSummary(task);
+
+    expect(summary.state).toBe("blocked");
+    expect(summary.blocker).toBe("awaiting approval");
+    expect(summary.nextAction).toBe("resolve blocker to continue");
+  });
+
+  it("AC-3: finished task produces finished state with last checkpoint", () => {
+    const task = makeTask({
+      status: "succeeded",
+      terminalSummary: "PR opened",
+    });
+
+    const summary = buildTaskOpsSummary(task);
+
+    expect(summary.state).toBe("finished");
+    expect(summary.lastCheckpoint).toBe("PR opened");
+    expect(summary.blocker).toBeUndefined();
+    expect(summary.nextAction).toBe("no action");
+  });
+
+  it("AC-4: failed task includes error as blocker", () => {
+    const task = makeTask({
+      status: "failed",
+      error: "timeout connecting to API",
+    });
+
+    const summary = buildTaskOpsSummary(task);
+
+    expect(summary.state).toBe("failed");
+    expect(summary.blocker).toBe("timeout connecting to API");
+    expect(summary.nextAction).toBe("investigate failure");
+  });
+
+  it("AC-5: flow enrichment adds flow-level blocker", () => {
+    const task = makeTask({
+      status: "running",
+      parentFlowId: "flow-1",
+      progressSummary: "waiting",
+    });
+    const flow = makeFlow({
+      status: "blocked",
+      blockedSummary: "needs credentials",
+    });
+
+    const summary = buildTaskOpsSummary(task, flow);
+
+    expect(summary.blocker).toBe("needs credentials");
+  });
+
+  it("queued task recommends waiting to start", () => {
+    const task = makeTask({
+      status: "queued",
+    });
+
+    const summary = buildTaskOpsSummary(task);
+
+    expect(summary.state).toBe("queued");
+    expect(summary.nextAction).toBe("waiting to start");
+  });
+
+  it("timed_out task recommends retry or extend timeout", () => {
+    const task = makeTask({
+      status: "timed_out",
+    });
+
+    const summary = buildTaskOpsSummary(task);
+
+    expect(summary.state).toBe("timed_out");
+    expect(summary.nextAction).toBe("retry or extend timeout");
+  });
+
+  it("lost task recommends checking session health", () => {
+    const task = makeTask({
+      status: "lost",
+      error: "session disappeared",
+    });
+
+    const summary = buildTaskOpsSummary(task);
+
+    expect(summary.state).toBe("lost");
+    expect(summary.blocker).toBe("session disappeared");
+    expect(summary.nextAction).toBe("check session health");
+  });
+
+  it("cancelled task reports no action", () => {
+    const task = makeTask({
+      status: "cancelled",
+    });
+
+    const summary = buildTaskOpsSummary(task);
+
+    expect(summary.state).toBe("cancelled");
+    expect(summary.nextAction).toBe("no action");
+  });
+
+  it("running task with no progressSummary omits checkpoint", () => {
+    const task = makeTask({
+      status: "running",
+    });
+
+    const summary = buildTaskOpsSummary(task);
+
+    expect(summary.state).toBe("active");
+    expect(summary.lastCheckpoint).toBeUndefined();
+  });
+
+  it("failed task falls back to terminalSummary when error is absent", () => {
+    const task = makeTask({
+      status: "failed",
+      terminalSummary: "build step crashed",
+    });
+
+    const summary = buildTaskOpsSummary(task);
+
+    expect(summary.blocker).toBe("build step crashed");
+  });
+
+  it("flow-level blocker takes priority over task-level blocker", () => {
+    const task = makeTask({
+      status: "succeeded",
+      terminalOutcome: "blocked",
+      terminalSummary: "task-level blocker",
+    });
+    const flow = makeFlow({
+      status: "blocked",
+      blockedSummary: "flow-level blocker",
+    });
+
+    const summary = buildTaskOpsSummary(task, flow);
+
+    expect(summary.blocker).toBe("flow-level blocker");
+  });
+
+  it("flow waiting status provides next action hint", () => {
+    const task = makeTask({
+      status: "running",
+      parentFlowId: "flow-1",
+    });
+    const flow = makeFlow({
+      status: "waiting",
+    });
+
+    const summary = buildTaskOpsSummary(task, flow);
+
+    // Running task has no nextAction from task-level, but flow could enrich
+    expect(summary.state).toBe("active");
+  });
+});
+
+describe("formatTaskOpsSummary", () => {
+  it("AC-6: formats full summary with all fields", () => {
+    const formatted = formatTaskOpsSummary({
+      state: "blocked",
+      lastCheckpoint: "patch applied",
+      blocker: "awaiting approval",
+      nextAction: "resolve blocker to continue",
+    });
+
+    expect(formatted).toBe(
+      "blocked · last good step: patch applied · awaiting approval · next: resolve blocker to continue",
+    );
+  });
+
+  it("formats minimal summary with state only", () => {
+    const formatted = formatTaskOpsSummary({
+      state: "active",
+    });
+
+    expect(formatted).toBe("active");
+  });
+
+  it("formats summary with state and checkpoint only", () => {
+    const formatted = formatTaskOpsSummary({
+      state: "active",
+      lastCheckpoint: "compiling assets",
+    });
+
+    expect(formatted).toBe("active · last good step: compiling assets");
+  });
+
+  it("formats finished task summary", () => {
+    const formatted = formatTaskOpsSummary({
+      state: "finished",
+      lastCheckpoint: "PR opened",
+      nextAction: "no action",
+    });
+
+    expect(formatted).toBe("finished · last good step: PR opened · next: no action");
+  });
+
+  it("formats failed task summary", () => {
+    const formatted = formatTaskOpsSummary({
+      state: "failed",
+      blocker: "timeout connecting to API",
+      nextAction: "investigate failure",
+    });
+
+    expect(formatted).toBe("failed · timeout connecting to API · next: investigate failure");
+  });
+
+  it("round-trips through build + format for a running task", () => {
+    const task = makeTask({
+      status: "running",
+      progressSummary: "step 3 of 5",
+    });
+
+    const formatted = formatTaskOpsSummary(buildTaskOpsSummary(task));
+
+    expect(formatted).toBe("active · last good step: step 3 of 5");
+  });
+
+  it("round-trips through build + format for a blocked task", () => {
+    const task = makeTask({
+      status: "succeeded",
+      terminalOutcome: "blocked",
+      terminalSummary: "awaiting approval",
+    });
+
+    const formatted = formatTaskOpsSummary(buildTaskOpsSummary(task));
+
+    expect(formatted).toBe(
+      "blocked · last good step: awaiting approval · awaiting approval · next: resolve blocker to continue",
+    );
+  });
+
+  it("round-trips through build + format for a finished task", () => {
+    const task = makeTask({
+      status: "succeeded",
+      terminalSummary: "PR opened",
+    });
+
+    const formatted = formatTaskOpsSummary(buildTaskOpsSummary(task));
+
+    expect(formatted).toBe("finished · last good step: PR opened · next: no action");
+  });
+});

--- a/src/tasks/task-ops-summary.ts
+++ b/src/tasks/task-ops-summary.ts
@@ -1,0 +1,171 @@
+import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import type { TaskRecord } from "./task-registry.types.js";
+import { sanitizeTaskStatusText } from "./task-status.js";
+
+/**
+ * Compact operational summary for a single task.
+ *
+ * Designed to answer four questions at a glance:
+ * 1. What state is the task in right now?
+ * 2. What was the last successful step?
+ * 3. What is blocking progress?
+ * 4. What should happen next?
+ */
+export type TaskOpsSummary = {
+  /** High-level operational state: active | queued | blocked | finished | failed | cancelled | lost | timed_out */
+  state: string;
+  /** Last known progress checkpoint or terminal summary, when available. */
+  lastCheckpoint?: string;
+  /** Current blocker description, when the task is blocked or failed. */
+  blocker?: string;
+  /** Recommended next action, when deterministically derivable. */
+  nextAction?: string;
+};
+
+const OPS_SUMMARY_MAX_FIELD_CHARS = 120;
+
+function sanitizeField(value: unknown, opts?: { errorContext?: boolean }): string | undefined {
+  const text = sanitizeTaskStatusText(value, {
+    errorContext: opts?.errorContext ?? false,
+    maxChars: OPS_SUMMARY_MAX_FIELD_CHARS,
+  });
+  return text || undefined;
+}
+
+function resolveOpsState(task: TaskRecord): string {
+  if (task.status === "running") {
+    return "active";
+  }
+  if (task.status === "succeeded") {
+    if (task.terminalOutcome === "blocked") {
+      return "blocked";
+    }
+    return "finished";
+  }
+  if (task.status === "queued") {
+    return "queued";
+  }
+  // failed, timed_out, cancelled, lost — pass through as-is
+  return task.status;
+}
+
+function resolveLastCheckpoint(task: TaskRecord): string | undefined {
+  // For active tasks, progressSummary is the current checkpoint
+  if (task.status === "running" || task.status === "queued") {
+    return sanitizeField(task.progressSummary);
+  }
+  // For terminal tasks, terminalSummary is the last known step
+  return sanitizeField(task.terminalSummary, { errorContext: true });
+}
+
+function resolveBlocker(task: TaskRecord, flow?: TaskFlowRecord): string | undefined {
+  // Flow-level blocker takes priority when present
+  if (flow?.blockedSummary) {
+    return sanitizeField(flow.blockedSummary, { errorContext: true });
+  }
+
+  // Task-level: blocked outcome
+  if (task.terminalOutcome === "blocked") {
+    return sanitizeField(task.terminalSummary, { errorContext: true });
+  }
+
+  // Task-level: failure error
+  if (task.status === "failed" || task.status === "timed_out" || task.status === "lost") {
+    return (
+      sanitizeField(task.error, { errorContext: true }) ??
+      sanitizeField(task.terminalSummary, { errorContext: true })
+    );
+  }
+
+  return undefined;
+}
+
+function resolveNextAction(task: TaskRecord, flow?: TaskFlowRecord): string | undefined {
+  // Finished with no blocker — nothing to do
+  if (task.status === "succeeded" && task.terminalOutcome !== "blocked") {
+    return "no action";
+  }
+
+  // Blocked — suggest unblocking
+  if (task.terminalOutcome === "blocked") {
+    return "resolve blocker to continue";
+  }
+
+  // Queued — waiting to start
+  if (task.status === "queued") {
+    return "waiting to start";
+  }
+
+  // Failed / timed_out / lost — suggest retry or investigation
+  if (task.status === "failed") {
+    return "investigate failure";
+  }
+  if (task.status === "timed_out") {
+    return "retry or extend timeout";
+  }
+  if (task.status === "lost") {
+    return "check session health";
+  }
+
+  // Cancelled — no action
+  if (task.status === "cancelled") {
+    return "no action";
+  }
+
+  // Flow-level waiting/blocked hints
+  if (flow) {
+    if (flow.status === "blocked" || flow.status === "waiting") {
+      if (flow.blockedSummary) {
+        return "resolve blocker to continue";
+      }
+      return "waiting for external input";
+    }
+  }
+
+  // Running — no recommended action (it's in progress)
+  return undefined;
+}
+
+/**
+ * Build a compact operational summary for a task.
+ *
+ * @param task - The TaskRecord to summarize.
+ * @param flow - Optional parent TaskFlowRecord for blocker enrichment.
+ * @returns A deterministic TaskOpsSummary derived purely from task/flow state.
+ */
+export function buildTaskOpsSummary(task: TaskRecord, flow?: TaskFlowRecord): TaskOpsSummary {
+  return {
+    state: resolveOpsState(task),
+    lastCheckpoint: resolveLastCheckpoint(task),
+    blocker: resolveBlocker(task, flow),
+    nextAction: resolveNextAction(task, flow),
+  };
+}
+
+/**
+ * Format a TaskOpsSummary into a compact single-line string.
+ *
+ * Output pattern: "<state> [· last good step: <checkpoint>] [· <blocker>] [· next: <action>]"
+ *
+ * Examples:
+ *   "active · last good step: compiling assets"
+ *   "blocked · awaiting approval · next: resolve blocker to continue"
+ *   "finished · last good step: PR opened · next: no action"
+ */
+export function formatTaskOpsSummary(summary: TaskOpsSummary): string {
+  const parts: string[] = [summary.state];
+
+  if (summary.lastCheckpoint) {
+    parts.push(`last good step: ${summary.lastCheckpoint}`);
+  }
+
+  if (summary.blocker) {
+    parts.push(summary.blocker);
+  }
+
+  if (summary.nextAction) {
+    parts.push(`next: ${summary.nextAction}`);
+  }
+
+  return parts.join(" · ");
+}


### PR DESCRIPTION
## Summary

- Add shared `buildTaskOpsSummary` / `formatTaskOpsSummary` utility that produces compact operational summaries (state, last checkpoint, blocker, next action) from `TaskRecord` + optional `TaskFlowRecord`
- Integrate into all three consumer surfaces: auto-reply `/tasks`, status-text session line, and CLI `tasks show`
- Replace hand-rolled phrasing in each surface with the single reusable builder for consistent messaging

## Changes

| File | Change |
|------|--------|
| `src/tasks/task-ops-summary.ts` | New shared summary builder (pure functions, no side effects) |
| `src/tasks/task-ops-summary.test.ts` | 21 unit tests covering all states, flow enrichment, format contract |
| `src/auto-reply/reply/commands-tasks.ts` | Append ops summary line to each visible task |
| `src/status/status-text.ts` | Replace title+detail with ops summary in session task line |
| `src/commands/tasks.ts` | Add `opsSummary:` line to `tasks show` output |

## Test plan

- [x] 21 new tests pass (`task-ops-summary.test.ts`)
- [x] 0 regressions across existing test suites (47 total tests pass)
- [ ] Manual verification: run `/tasks` in auto-reply, check status text, run `tasks show` CLI

Closes #80