### PR TITLE
fix: prevent doctor --fix from archiving historical session transcripts

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -286,16 +286,16 @@ describe("doctor state integrity oauth dir checks", () => {
     const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
     fs.writeFileSync(path.join(sessionsDir, "orphan-session.jsonl"), '{"type":"session"}\n');
     const confirmRuntimeRepair = vi.fn(async (params: { message: string }) =>
-      params.message.includes("This only renames them to *.deleted.<timestamp>."),
+      params.message.includes("hidden from session discovery"),
     );
     await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
     expect(stateIntegrityText()).toContain(
-      "These .jsonl files are no longer referenced by sessions.json",
+      "appear to be empty or stub transcripts not referenced by sessions.json",
     );
     expect(stateIntegrityText()).toContain("Examples: orphan-session.jsonl");
     expect(confirmRuntimeRepair).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining("This only renames them to *.deleted.<timestamp>."),
+        message: expect.stringContaining("hidden from session discovery"),
         requiresInteractiveConfirmation: true,
       }),
     );
@@ -356,13 +356,13 @@ describe("doctor state integrity oauth dir checks", () => {
         });
 
         const confirmRuntimeRepair = vi.fn(async (params: { message: string }) =>
-          params.message.includes("This only renames them to *.deleted.<timestamp>."),
+          params.message.includes("hidden from session discovery"),
         );
         await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
 
         expect(fs.existsSync(transcriptPath)).toBe(true);
         expect(fs.readdirSync(sessionsDir).some((name) => name.includes(".deleted."))).toBe(false);
-        expect(stateIntegrityText()).not.toContain("These .jsonl files are no longer referenced");
+        expect(stateIntegrityText()).not.toContain("appear to be empty or stub transcripts");
       } finally {
         fs.rmSync(symlinkHome, { force: true, recursive: true });
       }
@@ -373,7 +373,7 @@ describe("doctor state integrity oauth dir checks", () => {
     const confirmRuntimeRepair = await runOrphanTranscriptCheckWithQmdSessions(true, tempHome);
 
     expect(stateIntegrityText()).not.toContain(
-      "These .jsonl files are no longer referenced by sessions.json",
+      "appear to be empty or stub transcripts not referenced by sessions.json",
     );
     expect(confirmRuntimeRepair).not.toHaveBeenCalled();
   });
@@ -382,9 +382,57 @@ describe("doctor state integrity oauth dir checks", () => {
     const confirmRuntimeRepair = await runOrphanTranscriptCheckWithQmdSessions(false, tempHome);
 
     expect(stateIntegrityText()).toContain(
-      "These .jsonl files are no longer referenced by sessions.json",
+      "appear to be empty or stub transcripts not referenced by sessions.json",
     );
     expect(confirmRuntimeRepair).toHaveBeenCalled();
+  });
+
+  it("does not flag multi-line historical transcripts as orphans", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    // Write a multi-line transcript simulating real chat history — not referenced in sessions.json
+    // but should NOT be flagged as orphan because it contains substantial content.
+    const historicalContent = [
+      '{"type":"summary","sessionId":"old-session-123"}',
+      '{"type":"message","role":"human","content":"Hello"}',
+      '{"type":"message","role":"assistant","content":"Hi there!"}',
+      "",
+    ].join("\n");
+    fs.writeFileSync(path.join(sessionsDir, "old-session-123.jsonl"), historicalContent);
+    const confirmRuntimeRepair = vi.fn(async () => false);
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+    expect(stateIntegrityText()).not.toContain("appear to be empty or stub transcripts");
+    expect(stateIntegrityText()).not.toContain("old-session-123.jsonl");
+    // Should not even be prompted for archival
+    expect(confirmRuntimeRepair).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("orphan"),
+      }),
+    );
+    // File should remain untouched
+    const files = fs.readdirSync(sessionsDir);
+    expect(files).toContain("old-session-123.jsonl");
+    expect(files.some((name) => name.includes(".deleted."))).toBe(false);
+  });
+
+  it("flags empty transcripts not referenced in sessions.json as orphans", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    // Write an empty transcript file — this is a genuine orphan
+    fs.writeFileSync(path.join(sessionsDir, "empty-orphan.jsonl"), "");
+    const confirmRuntimeRepair = vi.fn(async (params: { message: string }) =>
+      params.message.includes("hidden from session discovery"),
+    );
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+    expect(stateIntegrityText()).toContain("appear to be empty or stub transcripts");
+    expect(stateIntegrityText()).toContain("empty-orphan.jsonl");
+    expect(confirmRuntimeRepair).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("hidden from session discovery"),
+      }),
+    );
   });
 
   it("prints openclaw-only verification hints when recent sessions are missing transcripts", async () => {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -908,20 +908,29 @@ export async function noteStateIntegrity(
       .map((entry) => path.join(sessionsDir, entry.name))
       .filter(
         (filePath) => !referencedTranscriptPaths.has(resolveComparableTranscriptPath(filePath)),
-      );
+      )
+      .filter((filePath) => {
+        // A transcript with >1 JSONL line is a legitimate historical session,
+        // not a true orphan. Only flag empty or stub files (≤1 line) as orphans.
+        // This prevents archiving valid chat history that is simply no longer
+        // the "current" session in sessions.json.
+        const lineCount = countJsonlLines(filePath);
+        return lineCount <= 1;
+      });
     if (orphanTranscriptPaths.length > 0 && !suppressOrphanTranscriptWarning) {
       const orphanCount = countLabel(orphanTranscriptPaths.length, "orphan transcript file");
       const orphanPreview = formatFilePreview(orphanTranscriptPaths);
       warnings.push(
         [
           `- Found ${orphanCount} in ${displaySessionsDir}.`,
-          "  These .jsonl files are no longer referenced by sessions.json, so they are not part of any active session history.",
-          "  Doctor can archive them safely by renaming each file to *.deleted.<timestamp>.",
+          "  These .jsonl files appear to be empty or stub transcripts not referenced by sessions.json.",
+          "  Doctor can archive them by renaming each file to *.deleted.<timestamp>.",
+          "  Archived files will be hidden from session history and memory search.",
           `  Examples: ${orphanPreview}`,
         ].join("\n"),
       );
       const archiveOrphans = await prompter.confirmRuntimeRepair({
-        message: `Archive ${orphanCount} in ${displaySessionsDir}? This only renames them to *.deleted.<timestamp>.`,
+        message: `Archive ${orphanCount} in ${displaySessionsDir}? Files will be renamed to *.deleted.<timestamp> and hidden from session discovery.`,
         initialValue: false,
         requiresInteractiveConfirmation: true,
       });

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -114,11 +114,15 @@ export function loadSessionStore(
       fileStat = getFileStatSnapshot(storePath) ?? fileStat;
       mtimeMs = fileStat?.mtimeMs;
       break;
-    } catch {
+    } catch (err) {
       if (attempt < maxReadAttempts - 1) {
         Atomics.wait(retryBuf!, 0, 0, 50);
         continue;
       }
+      log.warn("failed to parse sessions.json; session store will appear empty", {
+        storePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `openclaw doctor --fix` builds `referencedTranscriptPaths` only from `sessions.json`, which tracks only the most recent session per key. All prior session transcripts were falsely classified as orphans and archived, silently destroying chat history.
- **Fix**: Add a content-based filter using the existing `countJsonlLines()` helper — only empty or stub transcripts (≤1 JSONL line) are flagged as orphans. Multi-line transcripts are preserved as legitimate historical sessions.
- **Secondary fix**: `loadSessionStore()` now logs a warning when `sessions.json` fails to parse, instead of silently returning an empty store.

## Test plan

- [x] 18/18 tests pass in `doctor-state-integrity.test.ts`
- [x] New test: multi-line historical transcript is NOT flagged as orphan
- [x] New test: empty transcript IS flagged as orphan
- [x] 5 existing tests updated for new prompt wording (no semantic weakening)
- [x] Lint check passes (only pre-existing errors in unrelated files)

Closes #404