### PR TITLE
fix: prevent gateway stall from indefinite reload deferral and surface event-loop degradation in /readyz

### DIFF
--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -60,6 +60,7 @@ type GatewayReloadLog = {
 const MCP_RUNTIME_RELOAD_DISPOSE_TIMEOUT_MS = 5_000;
 const CHANNEL_RELOAD_DEFERRAL_POLL_MS = 500;
 const CHANNEL_RELOAD_STILL_PENDING_WARN_MS = 30_000;
+const DEFAULT_CHANNEL_RELOAD_DEFERRAL_TIMEOUT_MS = 300_000;
 
 function abortActiveAgentRunsAfterConfigRecovery(params: {
   reason: string;
@@ -191,7 +192,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     const timeoutMs =
       typeof timeoutMsRaw === "number" && Number.isFinite(timeoutMsRaw) && timeoutMsRaw > 0
         ? Math.max(CHANNEL_RELOAD_DEFERRAL_POLL_MS, Math.floor(timeoutMsRaw))
-        : undefined;
+        : DEFAULT_CHANNEL_RELOAD_DEFERRAL_TIMEOUT_MS;
     const startedAt = Date.now();
     let nextStillPendingAt = startedAt + CHANNEL_RELOAD_STILL_PENDING_WARN_MS;
     while (true) {
@@ -205,7 +206,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         return;
       }
       const elapsedMs = Date.now() - startedAt;
-      if (timeoutMs !== undefined && elapsedMs >= timeoutMs) {
+      if (elapsedMs >= timeoutMs) {
         const remaining = formatActiveDetails(current);
         params.logReload.warn(
           `channel reload timeout after ${elapsedMs}ms with ${remaining.join(

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -276,7 +276,7 @@ describe("createReadinessChecker", () => {
     });
   });
 
-  it("adds event-loop health to detailed readiness without changing readiness state", () => {
+  it("marks not ready when event-loop health is degraded", () => {
     withReadinessClock(() => {
       const { readiness } = createReadinessHarness({
         startedAgoMs: 5 * 60_000,
@@ -293,8 +293,8 @@ describe("createReadinessChecker", () => {
       });
 
       expect(readiness()).toEqual({
-        ready: true,
-        failing: [],
+        ready: false,
+        failing: ["event-loop-degraded"],
         uptimeMs: 300_000,
         eventLoop: {
           degraded: true,
@@ -304,6 +304,39 @@ describe("createReadinessChecker", () => {
           delayMaxMs: 88.7,
           utilization: 0.991,
           cpuCoreRatio: 0.973,
+        },
+      });
+    });
+  });
+
+  it("includes event-loop health without affecting readiness when not degraded", () => {
+    withReadinessClock(() => {
+      const { readiness } = createReadinessHarness({
+        startedAgoMs: 5 * 60_000,
+        accounts: {},
+        getEventLoopHealth: () => ({
+          degraded: false,
+          reasons: [],
+          intervalMs: 2_000,
+          delayP99Ms: 12.3,
+          delayMaxMs: 25.0,
+          utilization: 0.45,
+          cpuCoreRatio: 0.3,
+        }),
+      });
+
+      expect(readiness()).toEqual({
+        ready: true,
+        failing: [],
+        uptimeMs: 300_000,
+        eventLoop: {
+          degraded: false,
+          reasons: [],
+          intervalMs: 2_000,
+          delayP99Ms: 12.3,
+          delayMaxMs: 25.0,
+          utilization: 0.45,
+          cpuCoreRatio: 0.3,
         },
       });
     });

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -94,5 +94,16 @@ function withEventLoopHealth(
   getEventLoopHealth?: () => GatewayEventLoopHealth | undefined,
 ): ReadinessResult {
   const eventLoop = getEventLoopHealth?.();
-  return eventLoop ? { ...result, eventLoop } : result;
+  if (!eventLoop) {
+    return result;
+  }
+  if (eventLoop.degraded) {
+    return {
+      ...result,
+      ready: false,
+      failing: [...result.failing, "event-loop-degraded"],
+      eventLoop,
+    };
+  }
+  return { ...result, eventLoop };
 }


### PR DESCRIPTION
## Bug
- **Symptom**: Gateway main thread stalls at ~99.9% CPU under orchestration load; `/readyz` probes time out; reload/restart remains deferred indefinitely behind active task-run bookkeeping.
- **Root cause**: `waitForActiveWorkBeforeChannelReload` had no default timeout — when `gateway.reload.deferralTimeoutMs` was not configured, the channel reload loop ran indefinitely. Additionally, `/readyz` did not report failure when the event loop was degraded.

## Fix
1. Added `DEFAULT_CHANNEL_RELOAD_DEFERRAL_TIMEOUT_MS` (300s) as a hard ceiling for channel reload deferral. When no config-level timeout is set, the loop now always times out after 5 minutes instead of blocking forever.
2. Made `/readyz` return `ready: false` with `"event-loop-degraded"` in the failing list when the event loop health monitor reports `degraded: true`, so external probes can detect gateway stalls even when channel connections appear healthy.

## Verification
- Unit tests: 38 passed (readiness.test.ts: 12 tests, server-reload-handlers.test.ts: 2 tests, plus related files)
- Updated existing test to reflect new behavior (event-loop degraded → not ready)
- Added new test for healthy event-loop passthrough

Closes #407