### PR TITLE
fix: send follow-up mention notification after streaming card close (#406)

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1141,4 +1141,138 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       nowSpy.mockRestore();
     }
   });
+
+  // --- Streaming @mention notification follow-up (#73469) ---
+
+  it("sends a follow-up mention notification after streaming card close", async () => {
+    const mentionTargets = [
+      { openId: "ou_user1", name: "Alice", key: "@_user_1" },
+      { openId: "ou_user2", name: "Bob", key: "@_user_2" },
+    ];
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+      mentionTargets,
+    });
+
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    // The close text should contain card-format mention tags
+    const closeText = streamingInstances[0].close.mock.calls[0]?.[0] as string;
+    expect(closeText).toContain("<at id=ou_user1></at>");
+    expect(closeText).toContain("<at id=ou_user2></at>");
+
+    // Follow-up text message triggers Feishu push notification
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "oc_chat",
+        text: "☝️",
+        mentions: mentionTargets,
+      }),
+    );
+  });
+
+  it("does not send follow-up mention notification when no mentionTargets", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("does not send follow-up mention notification when mentionTargets is empty", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+      mentionTargets: [],
+    });
+
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("logs but does not throw when follow-up mention notification fails", async () => {
+    const errorSpy = vi.fn();
+    sendMessageFeishuMock.mockRejectedValueOnce(new Error("network error"));
+
+    const mentionTargets = [{ openId: "ou_user1", name: "Alice", key: "@_user_1" }];
+    const { options } = createDispatcherHarness({
+      runtime: { log: vi.fn(), error: errorSpy } as never,
+      mentionTargets,
+    });
+
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+    // Should not throw
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("mention follow-up notification failed"),
+    );
+  });
+
+  it("does not double-notify mentions on non-streaming card path", async () => {
+    const mentionTargets = [{ openId: "ou_user1", name: "Alice", key: "@_user_1" }];
+
+    // Non-streaming: renderMode=auto, streaming=false
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: { renderMode: "auto", streaming: false },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: createRuntimeLogger(),
+      chatId: "oc_chat",
+      mentionTargets,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    // Markdown text triggers card path — non-streaming goes to sendStructuredCardFeishu
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mentions: mentionTargets }),
+    );
+    // No follow-up text message — mentions already handled by the card send
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("sends exactly one follow-up mention after streaming close, not on duplicate final", async () => {
+    const mentionTargets = [{ openId: "ou_user1", name: "Alice", key: "@_user_1" }];
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+      mentionTargets,
+    });
+
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+    await options.onIdle?.();
+
+    // Duplicate final after streaming close — should be skipped by the
+    // streamingClosedForReply guard
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    // Only one follow-up notification from the streaming close, not from the
+    // duplicate final delivery
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -384,6 +384,28 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             streamingClosedForReply = true;
           }
         }
+
+        // Streaming card element updates (PUT) do not trigger Feishu push
+        // notifications — only im.message.create / reply does.  When the
+        // card contained @mentions, send a lightweight follow-up text
+        // message so mentioned users receive a notification.  (#73469)
+        if (mentionTargets?.length) {
+          try {
+            await sendMessageFeishu({
+              cfg,
+              to: chatId,
+              text: "☝️",
+              replyToMessageId: sendReplyToMessageId,
+              replyInThread: effectiveReplyInThread,
+              mentions: mentionTargets,
+              accountId,
+            });
+          } catch (mentionNotifyError) {
+            params.runtime.error?.(
+              `feishu[${account.accountId}]: mention follow-up notification failed: ${String(mentionNotifyError)}`,
+            );
+          }
+        }
       }
     } finally {
       streaming = null;


### PR DESCRIPTION
## Summary

Fixes #406 — Streaming cards don't send @mention notifications when agent writes `<at>` tags in text.

- **Root cause**: Feishu Card Kit streaming element updates (PUT) do not trigger push notifications — only `im.message.create`/`reply` does. The `closeStreaming()` function embedded mention tags in card content via element update, which rendered visually but didn't notify.
- **Fix**: After streaming card closes with mentions, send a lightweight follow-up text message via `sendMessageFeishu()` containing `"☝️"` with mention targets. This uses `im.message.reply` which triggers Feishu's notification system.
- **Guard**: Fix is gated by `mentionTargets?.length` and only fires inside the `if (streaming?.isActive())` block — non-streaming paths are unaffected.
- **Error handling**: Non-fatal try/catch with `runtime.error` logging.

## Test plan

- [x] 6 new tests added covering all acceptance criteria:
  - AC-1: Follow-up mention notification sent after streaming card close
  - AC-2: No follow-up when no mentionTargets / empty mentionTargets
  - AC-3: Error logged but not thrown when follow-up fails
  - AC-4: Non-streaming card path not affected (no double-notify)
  - AC-5: Exactly one follow-up per streaming close (duplicate final guard)
- [x] All 47 tests pass (41 existing + 6 new)
- [x] TypeScript compilation — no new errors introduced (pre-existing module resolution errors only)