### PR TITLE
fix: wake Slack agents on subteam user-group mentions

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -62,6 +62,10 @@ import { resolveSlackThreadStarter } from "../thread.js";
 import { resolveSlackMessageContent } from "./prepare-content.js";
 import { resolveSlackRoutingContext } from "./prepare-routing.js";
 import { resolveSlackThreadContextData } from "./prepare-thread-context.js";
+import {
+  extractSlackSubteamMentionIds,
+  matchesConfiguredSubteamMention,
+} from "./subteam-mentions.js";
 import type { PreparedSlackMessage } from "./types.js";
 
 const mentionRegexCache = new WeakMap<SlackMonitorContext, Map<string, RegExp[]>>();
@@ -287,6 +291,8 @@ export async function prepareSlackMessage(params: {
   const explicitlyMentioned = Boolean(
     ctx.botUserId && message.text?.includes(`<@${ctx.botUserId}>`),
   );
+  const subteamIds = extractSlackSubteamMentionIds(message.text);
+  const hasAnySubteamMention = subteamIds.length > 0;
   const seedTopLevelRoomThreadBySource =
     opts.source === "app_mention" || opts.wasMentioned === true || explicitlyMentioned;
   let routing = resolveSlackRoutingContext({
@@ -300,20 +306,26 @@ export async function prepareSlackMessage(params: {
     seedTopLevelRoomThread: seedTopLevelRoomThreadBySource,
   });
 
-  const resolveWasMentioned = (mentionRegexes: RegExp[]) =>
-    opts.wasMentioned ??
-    (!isDirectMessage &&
-      matchesMentionWithExplicit({
-        text: message.text ?? "",
-        mentionRegexes,
-        explicit: {
-          hasAnyMention,
-          isExplicitlyMentioned: explicitlyMentioned,
-          canResolveExplicit: Boolean(ctx.botUserId),
-        },
-      }));
+  const resolveWasMentioned = (mentionRegexes: RegExp[], agentId: string | undefined) => {
+    const subteamMentioned =
+      hasAnySubteamMention && matchesConfiguredSubteamMention({ subteamIds, cfg, agentId });
+    const isExplicitlyMentioned = explicitlyMentioned || subteamMentioned;
+    return (
+      opts.wasMentioned ??
+      (!isDirectMessage &&
+        matchesMentionWithExplicit({
+          text: message.text ?? "",
+          mentionRegexes,
+          explicit: {
+            hasAnyMention: hasAnyMention || hasAnySubteamMention,
+            isExplicitlyMentioned,
+            canResolveExplicit: Boolean(ctx.botUserId),
+          },
+        }))
+    );
+  };
   let mentionRegexes = resolveCachedMentionRegexes(ctx, routing.route.agentId);
-  let wasMentioned = resolveWasMentioned(mentionRegexes);
+  let wasMentioned = resolveWasMentioned(mentionRegexes, routing.route.agentId);
   const hasRuntimeBoundSession = Boolean(routing.runtimeBoundSessionKey);
   // Runtime bindings already pin the root and later thread replies to the same
   // target session, so only unbound regex mentions need a seeded thread reroute.
@@ -335,7 +347,7 @@ export async function prepareSlackMessage(params: {
       seedTopLevelRoomThread: true,
     });
     mentionRegexes = resolveCachedMentionRegexes(ctx, routing.route.agentId);
-    wasMentioned = resolveWasMentioned(mentionRegexes);
+    wasMentioned = resolveWasMentioned(mentionRegexes, routing.route.agentId);
   }
   const {
     route,

--- a/extensions/slack/src/monitor/message-handler/subteam-mentions.test.ts
+++ b/extensions/slack/src/monitor/message-handler/subteam-mentions.test.ts
@@ -1,0 +1,208 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { describe, expect, it } from "vitest";
+import {
+  extractSlackSubteamMentionIds,
+  matchesConfiguredSubteamMention,
+} from "./subteam-mentions.js";
+
+describe("extractSlackSubteamMentionIds", () => {
+  it("extracts a single subteam id", () => {
+    expect(extractSlackSubteamMentionIds("<!subteam^S0B07LS458B> ping")).toEqual(["S0B07LS458B"]);
+  });
+
+  it("extracts multiple distinct subteam ids", () => {
+    const text = "<!subteam^S0B07LS458B> and <!subteam^SOTHER123> hello";
+    const ids = extractSlackSubteamMentionIds(text);
+    expect(ids).toHaveLength(2);
+    expect(ids).toContain("S0B07LS458B");
+    expect(ids).toContain("SOTHER123");
+  });
+
+  it("deduplicates repeated ids", () => {
+    const text = "<!subteam^S0B07LS458B> and <!subteam^S0B07LS458B> again";
+    expect(extractSlackSubteamMentionIds(text)).toEqual(["S0B07LS458B"]);
+  });
+
+  it("normalizes ids to uppercase", () => {
+    expect(extractSlackSubteamMentionIds("<!subteam^s0b07ls458b> hi")).toEqual(["S0B07LS458B"]);
+  });
+
+  it("handles subteam mention with display name suffix", () => {
+    expect(extractSlackSubteamMentionIds("<!subteam^S0B07LS458B|@my-group> hi")).toEqual([
+      "S0B07LS458B",
+    ]);
+  });
+
+  it("returns empty array for no subteam mentions", () => {
+    expect(extractSlackSubteamMentionIds("hello <@U123> world")).toEqual([]);
+  });
+
+  it("returns empty array for null/undefined/empty", () => {
+    expect(extractSlackSubteamMentionIds(null)).toEqual([]);
+    expect(extractSlackSubteamMentionIds(undefined)).toEqual([]);
+    expect(extractSlackSubteamMentionIds("")).toEqual([]);
+  });
+
+  it("ignores malformed subteam tokens", () => {
+    expect(extractSlackSubteamMentionIds("<!subteam> missing caret")).toEqual([]);
+    expect(extractSlackSubteamMentionIds("<subteam^S123> missing bang")).toEqual([]);
+  });
+});
+
+describe("matchesConfiguredSubteamMention", () => {
+  const baseCfg: OpenClawConfig = {};
+
+  it("returns false when no subteam ids in message", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      messages: { groupChat: { subteamMentions: ["S0B07LS458B"] } },
+    };
+    expect(matchesConfiguredSubteamMention({ subteamIds: [], cfg, agentId: undefined })).toBe(
+      false,
+    );
+  });
+
+  it("returns false when feature is not configured", () => {
+    expect(
+      matchesConfiguredSubteamMention({
+        subteamIds: ["S0B07LS458B"],
+        cfg: baseCfg,
+        agentId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("matches against global subteamMentions", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      messages: { groupChat: { subteamMentions: ["S0B07LS458B"] } },
+    };
+    expect(
+      matchesConfiguredSubteamMention({
+        subteamIds: ["S0B07LS458B"],
+        cfg,
+        agentId: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not match when subteam is not in allowlist", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      messages: { groupChat: { subteamMentions: ["S0B07LS458B"] } },
+    };
+    expect(
+      matchesConfiguredSubteamMention({
+        subteamIds: ["SOTHER"],
+        cfg,
+        agentId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("matches against per-agent subteamMentions", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      agents: {
+        list: [{ id: "jack", groupChat: { subteamMentions: ["S0B07LS458B"] } }],
+      },
+    };
+    expect(
+      matchesConfiguredSubteamMention({
+        subteamIds: ["S0B07LS458B"],
+        cfg,
+        agentId: "jack",
+      }),
+    ).toBe(true);
+  });
+
+  it("agent override shadows global (presence-as-override)", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      messages: { groupChat: { subteamMentions: ["S0B07LS458B"] } },
+      agents: {
+        list: [{ id: "jack", groupChat: { subteamMentions: ["SOTHER"] } }],
+      },
+    };
+    // jack's list overrides global — S0B07LS458B is NOT in jack's list
+    expect(
+      matchesConfiguredSubteamMention({
+        subteamIds: ["S0B07LS458B"],
+        cfg,
+        agentId: "jack",
+      }),
+    ).toBe(false);
+    // SOTHER IS in jack's list
+    expect(
+      matchesConfiguredSubteamMention({
+        subteamIds: ["SOTHER"],
+        cfg,
+        agentId: "jack",
+      }),
+    ).toBe(true);
+  });
+
+  it("explicit empty array on agent opts out even when global is set", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      messages: { groupChat: { subteamMentions: ["S0B07LS458B"] } },
+      agents: {
+        list: [{ id: "jack", groupChat: { subteamMentions: [] } }],
+      },
+    };
+    expect(
+      matchesConfiguredSubteamMention({
+        subteamIds: ["S0B07LS458B"],
+        cfg,
+        agentId: "jack",
+      }),
+    ).toBe(false);
+  });
+
+  it("agent without groupChat falls back to global", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      messages: { groupChat: { subteamMentions: ["S0B07LS458B"] } },
+      agents: {
+        list: [{ id: "amanda" }],
+      },
+    };
+    expect(
+      matchesConfiguredSubteamMention({
+        subteamIds: ["S0B07LS458B"],
+        cfg,
+        agentId: "amanda",
+      }),
+    ).toBe(true);
+  });
+
+  it("compares case-insensitively", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      messages: { groupChat: { subteamMentions: ["s0b07ls458b"] } },
+    };
+    expect(
+      matchesConfiguredSubteamMention({
+        subteamIds: ["S0B07LS458B"],
+        cfg,
+        agentId: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when agentId is not in agents list", () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      messages: { groupChat: { subteamMentions: ["S0B07LS458B"] } },
+      agents: { list: [{ id: "other" }] },
+    };
+    // Falls back to global since agent not found
+    expect(
+      matchesConfiguredSubteamMention({
+        subteamIds: ["S0B07LS458B"],
+        cfg,
+        agentId: "nonexistent",
+      }),
+    ).toBe(true);
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/subteam-mentions.ts
+++ b/extensions/slack/src/monitor/message-handler/subteam-mentions.ts
@@ -1,0 +1,74 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+
+/**
+ * Regex that matches Slack subteam (user-group) mention tokens.
+ * Slack encodes them as `<!subteam^SXXXXXX>` or `<!subteam^SXXXXXX|@group-name>`.
+ */
+const SUBTEAM_MENTION_RE = /<!subteam\^([A-Z0-9]+)(?:\|[^>]*)?>/gi;
+
+/**
+ * Extract all Slack subteam IDs from a message text.
+ * Returns an array of unique, uppercase subteam IDs.
+ *
+ * Example: `"<!subteam^S0B07LS458B> ping"` → `["S0B07LS458B"]`
+ */
+export function extractSlackSubteamMentionIds(text: string | undefined | null): string[] {
+  if (!text) {
+    return [];
+  }
+  const ids = new Set<string>();
+  let match: RegExpExecArray | null;
+  // Reset lastIndex since the regex is global
+  SUBTEAM_MENTION_RE.lastIndex = 0;
+  while ((match = SUBTEAM_MENTION_RE.exec(text)) !== null) {
+    ids.add(match[1].toUpperCase());
+  }
+  return [...ids];
+}
+
+/**
+ * Resolve the configured subteam mention allowlist for a given agent,
+ * using presence-as-override semantics:
+ * - If the agent defines `groupChat.subteamMentions` (even as `[]`), use it.
+ * - Otherwise fall back to the global `messages.groupChat.subteamMentions`.
+ * - If neither is configured, return `undefined` (feature not configured).
+ */
+function resolveSubteamMentions(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+): string[] | undefined {
+  if (agentId) {
+    const agentEntry = cfg.agents?.list?.find((a) => a.id === agentId);
+    const agentGroupChat = agentEntry?.groupChat;
+    if (agentGroupChat && Object.hasOwn(agentGroupChat, "subteamMentions")) {
+      return agentGroupChat.subteamMentions ?? [];
+    }
+  }
+  const globalGroupChat = cfg.messages?.groupChat;
+  if (globalGroupChat && Object.hasOwn(globalGroupChat, "subteamMentions")) {
+    return globalGroupChat.subteamMentions ?? [];
+  }
+  return undefined;
+}
+
+/**
+ * Check whether any of the extracted subteam IDs match the agent's configured
+ * allowlist. Returns `false` when the feature is not configured or the allowlist
+ * is empty.
+ */
+export function matchesConfiguredSubteamMention(params: {
+  subteamIds: string[];
+  cfg: OpenClawConfig;
+  agentId: string | undefined;
+}): boolean {
+  const { subteamIds, cfg, agentId } = params;
+  if (subteamIds.length === 0) {
+    return false;
+  }
+  const allowlist = resolveSubteamMentions(cfg, agentId);
+  if (!allowlist || allowlist.length === 0) {
+    return false;
+  }
+  const normalizedAllowlist = new Set(allowlist.map((id) => id.toUpperCase()));
+  return subteamIds.some((id) => normalizedAllowlist.has(id));
+}

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -3,6 +3,14 @@ import type { TtsConfig } from "./types.tts.js";
 
 export type GroupChatConfig = {
   mentionPatterns?: string[];
+  /**
+   * Slack subteam (user-group) IDs that should be treated as explicit mentions.
+   * When a message contains `<!subteam^SXXX>` and `SXXX` is in this list, the
+   * agent treats it as an @-mention. Resolved with presence-as-override semantics:
+   * an explicit empty array on an agent opts that agent out even when a global
+   * list is set. IDs are compared case-insensitively.
+   */
+  subteamMentions?: string[];
   historyLimit?: number;
   /**
    * Controls how group/channel turns produce visible room replies.


### PR DESCRIPTION
## Summary

Fixes #224 — Slack agents now wake on `<!subteam^SXXX>` user-group mentions when the subteam ID is in a configured allowlist.

### Changes

- **`GroupChatConfig.subteamMentions?: string[]`** — New config field (presence-as-override semantics: per-agent overrides global, explicit empty array opts out)
- **`subteam-mentions.ts`** — Helper module: `extractSlackSubteamMentionIds` parses `<!subteam^...>` tokens, `matchesConfiguredSubteamMention` checks against config allowlist
- **`prepare.ts`** — Integrates subteam check into `resolveWasMentioned` (now agent-aware); feeds result into `matchesMentionWithExplicit` as an explicit mention signal

### Configuration example

```yaml
messages:
  groupChat:
    subteamMentions: ["S12345", "S67890"]  # global

agents:
  list:
    - id: my-agent
      groupChat:
        subteamMentions: ["S11111"]  # overrides global for this agent
    - id: opt-out-agent
      groupChat:
        subteamMentions: []  # explicitly opts out
```

## Test plan

- [x] 18 new unit tests in `subteam-mentions.test.ts` (extraction + matching + presence-as-override + case-insensitive)
- [x] 42/42 existing `prepare.test.ts` regression tests pass
- [x] `tsc --noEmit` — no new TypeScript errors