### PR TITLE
fix: load channel plugins for openclaw status text output

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -93,7 +93,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
     commandPath: ["status"],
     policy: {
-      loadPlugins: "never",
+      loadPlugins: "text-only",
       routeConfigGuard: "when-suppressed",
       ensureCliPath: false,
       networkProxy: "bypass",

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -43,7 +43,7 @@ describe("command-startup-policy", () => {
         commandPath: ["status"],
         jsonOutputMode: false,
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       shouldLoadPluginsForCommandPath({
         commandPath: ["status"],


### PR DESCRIPTION
## Summary

Fixes #226

- Changed `loadPlugins` policy for the `status` command from `"never"` to `"text-only"` in `src/cli/command-catalog.ts`
- This ensures the plugin registry is loaded for human-readable CLI output, so `listChannelPlugins()` returns configured channels (e.g. Telegram) instead of an empty array
- JSON mode (`--json`) still skips plugin loading for fast path performance
- Updated the startup policy test to match the new expected behavior

## Root Cause

The `status` command entry in `cliCommandCatalog` had `loadPlugins: "never"`, which prevented `ensureCliPluginRegistryLoaded()` from running during the preAction bootstrap. Without the plugin registry, `listChannelPlugins()` returned `[]`, causing `buildChannelsTable()` to produce an empty Channels table.

The codebase already anticipated this fix — `resolvePluginRegistryScopeForCommandPath` maps `"status"` to the `"channels"` scope, and other similar commands like `agents list` already use `"text-only"`.

## Test plan

- [x] `src/cli/command-startup-policy.test.ts` — 6/6 passed (updated assertion for status text mode)
- [x] `src/commands/status.test.ts` — 13/13 passed (existing channel rendering tests)